### PR TITLE
versioned activity feed implementation

### DIFF
--- a/src/ActivityEntry.php
+++ b/src/ActivityEntry.php
@@ -20,7 +20,7 @@ class ActivityEntry extends ArrayData
 
     public static function createFromSnapshotItem(SnapshotItem $item)
     {
-        if ($item->LinkedToObject()->exists()) {
+        if ($item->LinkedToObjectID > 0 && $item->LinkedToObject()->exists()) {
             return new static([
                 'Subject' => $item->LinkedToObject(),
                 'Action' => $item->WasDeleted ? self::REMOVED : self::ADDED,


### PR DESCRIPTION
AC
 - Allows to list all changes between two versions of an owner (incl. direct and indirect owned relations)

https://github.com/silverstripe/silverstripe-versioned/issues/195