### PR TITLE
NEW Allow pausing snapshots globally

### DIFF
--- a/_config/tests.yml
+++ b/_config/tests.yml
@@ -1,0 +1,9 @@
+---
+Name: snapshotssapphiretest
+Before: '#sapphiretest'
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Dev\State\SapphireTestState:
+    properties:
+      States:
+        disablesnapshots: '%$SilverStripe\Snapshots\Dev\State\DisableSnapshots'

--- a/src/Dev/State/DisableSnapshots.php
+++ b/src/Dev/State/DisableSnapshots.php
@@ -6,6 +6,13 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\State\TestState;
 use SilverStripe\Snapshots\SnapshotPublishable;
 
+/**
+ * Disable snapshots in tests by default. Snapshots will analyze a relationship tree for objects when they are saved but
+ * fixtures will not necessarily scaffold all required tables for this when the test state is scaffolded.
+ *
+ * Tests that rely on snapshot functionality should explicitly opt-in to snapshots by calling
+ * `SnapshotPublishable::resume`.
+ */
 class DisableSnapshots implements TestState
 {
 

--- a/src/Dev/State/DisableSnapshots.php
+++ b/src/Dev/State/DisableSnapshots.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SilverStripe\Snapshots\Dev\State;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\State\TestState;
+use SilverStripe\Snapshots\SnapshotPublishable;
+
+class DisableSnapshots implements TestState
+{
+
+    /**
+     * Called on setup
+     *
+     * @param SapphireTest $test
+     */
+    public function setUp(SapphireTest $test)
+    {
+        // Skip tests in this modules' namespace
+        if (strpos(get_class($test), 'SilverStripe\\Snapshots\\') === 0) {
+            return;
+        }
+
+        SnapshotPublishable::pause();
+    }
+
+    /**
+     * Called on tear down
+     *
+     * @param SapphireTest $test
+     */
+    public function tearDown(SapphireTest $test)
+    {
+        SnapshotPublishable::resume();
+    }
+
+    /**
+     * Called once on setup
+     *
+     * @param string $class Class being setup
+     */
+    public function setUpOnce($class)
+    {
+        // noop
+    }
+
+    /**
+     * Called once on tear down
+     *
+     * @param string $class Class being torn down
+     */
+    public function tearDownOnce($class)
+    {
+        // noop
+    }
+}

--- a/src/SnapshotPublishable.php
+++ b/src/SnapshotPublishable.php
@@ -29,6 +29,13 @@ class SnapshotPublishable extends RecursivePublishable
     protected $activeSnapshot = null;
 
     /**
+     * Indicates if snapshotting is currently active. Control this state with the ::pause and ::resume methods
+     *
+     * @var bool
+     */
+    protected static $active = true;
+
+    /**
      * @param $class
      * @param $id
      * @param string|int $snapshot A snapshot ID or a Y-m-d h:i:s date formatted string
@@ -63,6 +70,10 @@ class SnapshotPublishable extends RecursivePublishable
      */
     public function publishRecursive()
     {
+        if (!self::$active) {
+            return parent::publishRecursive();
+        }
+
         $this->openSnapshot();
         $result = parent::publishRecursive();
         $this->closeSnapshot();
@@ -72,6 +83,10 @@ class SnapshotPublishable extends RecursivePublishable
 
     public function rollbackRelations($version)
     {
+        if (!self::$active) {
+            return parent::rollbackRelations($version);
+        }
+
         $this->openSnapshot();
         parent::rollbackRelations($version);
         $this->closeSnapshot();
@@ -537,6 +552,15 @@ class SnapshotPublishable extends RecursivePublishable
         }
     }
 
+    public static function pause()
+    {
+        self::$active = false;
+    }
+
+    public static function resume()
+    {
+        self::$active = true;
+    }
 
     /**
      * @param array $snapShotIDs
@@ -573,6 +597,11 @@ class SnapshotPublishable extends RecursivePublishable
      */
     protected function requiresSnapshot()
     {
+        // Check if snapshotting is currently "paused"
+        if (!self::$active) {
+            return false;
+        }
+
         $owner = $this->owner;
 
         // Explicitly blacklist these two, since they get so many writes in this context,

--- a/src/SnapshotPublishable.php
+++ b/src/SnapshotPublishable.php
@@ -552,11 +552,19 @@ class SnapshotPublishable extends RecursivePublishable
         }
     }
 
+    /**
+     * Pause snapshotting - disabling tracking version changes across a versioned owner relationship tree. This should
+     * only be done in cases where you are manually creating a snapshot (or you are _really_ sure that you don't want a
+     * change to be tracked own "owner"s of a record.
+     */
     public static function pause()
     {
         self::$active = false;
     }
 
+    /**
+     * Resume snapshotting after previously calling `SnapshotPublishable::pause`.
+     */
     public static function resume()
     {
         self::$active = true;


### PR DESCRIPTION
This is now used to disable snapshots during tests (for performance and to reduce test bleed). Tests relying on snapshot functionality may resume snapshotting by using the resume API in your setUp function in your test

At the moment it's very possible (read; extremely likely)  that client code test will break with undefined tables. This is because there are _many_ more tables that are now affected when writing an "owned" record - there's a lot more tables that need scaffolding. I'll raise a separate issue about somehow expanding SapphireTest to correctly scaffold all required tables for a test - but my personal opinion is that we _really_ __really__ don't want to go down that highly complex route.