### PR TITLE
Deleted versions show the prior versions to users

### DIFF
--- a/src/ActivityEntry.php
+++ b/src/ActivityEntry.php
@@ -40,8 +40,16 @@ class ActivityEntry extends ArrayData
             $flag = self::MODIFIED;
         }
 
+        // The item is used to show the user a title etc for the item
+        // Since the deleted version doesn't have that we want the prior version
+        if ($item->WasDeleted && $item->Version > 1) {
+            $itemObj = $item->getItem($item->Version - 1);
+        } else {
+            $itemObj = $item->getItem();
+        }
+
         return new static([
-            'Subject' => $item->getItem(),
+            'Subject' => $itemObj,
             'Action' => $flag,
             'Owner' => null,
             'Date' => $item->obj('Created')->Nice(),

--- a/src/SnapshotItem.php
+++ b/src/SnapshotItem.php
@@ -99,11 +99,13 @@ class SnapshotItem extends DataObject
     }
 
     /**
+     * @param int|null $version
      * @return DataObject
      */
-    public function getItem()
+    public function getItem(?int $version = null)
     {
-        return Versioned::get_version($this->ObjectClass, $this->ObjectID, $this->Version);
+        $version = $version ?? $this->Version;
+        return Versioned::get_version($this->ObjectClass, $this->ObjectID, $version);
     }
 
     public function getItemTitle()


### PR DESCRIPTION
In the frontend we get an error as snapshot is hitting `$activity->Subject->singular_name(),` which is null. The solution is to show the prior version as it has a title and it's going to be readable by humans as the version that was deleted

Should resolve https://github.com/silverstripe/silverstripe-versioned-snapshots/issues/15