### PR TITLE
use instance check in getManyManyLinking call

### DIFF
--- a/src/SnapshotPublishable.php
+++ b/src/SnapshotPublishable.php
@@ -512,7 +512,6 @@ class SnapshotPublishable extends RecursivePublishable
         /* @var DataObject|SnapshotPublishable $owner */
         $owner = $this->owner;
         $config = [];
-        $ownerClass = $owner->baseClass();
 
         // Has to have two has_ones
         $hasOnes = $owner->hasOne();
@@ -527,7 +526,7 @@ class SnapshotPublishable extends RecursivePublishable
                 if (!is_array($spec)) {
                     continue;
                 }
-                if ($spec['through'] !== $ownerClass) {
+                if (!($owner instanceof $spec['through'])) {
                     continue;
                 }
                 if (!isset($config[$class])) {

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -14,6 +14,7 @@ use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Gallery;
 use SilverStripe\Snapshots\Tests\SnapshotTest\GalleryImage;
+use SilverStripe\Snapshots\Tests\SnapshotTest\BaseJoin;
 use SilverStripe\Snapshots\Tests\SnapshotTest\GalleryImageJoin;
 use SilverStripe\Versioned\ChangeSetItem;
 use SilverStripe\Versioned\Versioned;
@@ -30,6 +31,7 @@ class SnapshotTest extends FunctionalTest
         Block::class,
         Gallery::class,
         GalleryImage::class,
+        BaseJoin::class,
         GalleryImageJoin::class,
         ChangeSetItem::class,
     ];

--- a/tests/SnapshotTest/BaseJoin.php
+++ b/tests/SnapshotTest/BaseJoin.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\Snapshots\Tests\SnapshotTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Base join class to ensure through objects can be subclasses of things other than DataObject
+ */
+class BaseJoin extends DataObject implements TestOnly
+{
+    private static $extensions = [
+        Versioned::class,
+    ];
+}

--- a/tests/SnapshotTest/GalleryImageJoin.php
+++ b/tests/SnapshotTest/GalleryImageJoin.php
@@ -1,13 +1,11 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Tests\SnapshotTest;
 
 use SilverStripe\Dev\TestOnly;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 
-class GalleryImageJoin extends DataObject implements TestOnly
+class GalleryImageJoin extends BaseJoin implements TestOnly
 {
     private static $has_one = [
         'Gallery' => Gallery::class,


### PR DESCRIPTION
a many-many spec may not always refer to the base class for a relation
this changes the check from a string comparision with the base class to
an instanceof check