### PR TITLE
Fix draft pages showing modified in sitetree

### DIFF
--- a/src/SnapshotPublishable.php
+++ b/src/SnapshotPublishable.php
@@ -325,7 +325,7 @@ class SnapshotPublishable extends RecursivePublishable
         $minVersion = Versioned::get_versionnumber_by_stage($class, Versioned::LIVE, $id);
 
         if (is_null($minVersion)) {
-            $minVersion = 1;
+            return false; //Draft page.
         }
 
         $result = SnapshotItem::get()


### PR DESCRIPTION
Issue: When creating a new page, in site tree page shows as a Modified page instead Draft page.

Full SiteTree view 
![Screen Shot 2019-10-25 at 3 56 14 PM](https://user-images.githubusercontent.com/20032948/67539986-5787dc80-f740-11e9-9eb2-e176e5275916.png)

When inside a page - left side siteTree
![Screen Shot 2019-10-25 at 3 56 37 PM](https://user-images.githubusercontent.com/20032948/67540016-6ec6ca00-f740-11e9-8eea-cab04ade6daf.png)

