### PR TITLE
FIX null being returned from get_published_version_number

### DIFF
--- a/src/SnapshotPublishable.php
+++ b/src/SnapshotPublishable.php
@@ -43,7 +43,7 @@ class SnapshotPublishable extends RecursivePublishable
      * @param int $id
      * @return int
      */
-    public static function get_published_version_number(string $class, int $id): int
+    public static function get_published_version_number(string $class, int $id): ?int
     {
         $inst = $class::singleton();
         if (!$inst->hasExtension(Versioned::class)) {


### PR DESCRIPTION
`Versioned::get_versionnumber_by_stage` can return null, which throws an error here