### PR TITLE
FIX: Track deletions correctly

### DIFF
--- a/src/Handler/Form/Handler.php
+++ b/src/Handler/Form/Handler.php
@@ -74,13 +74,18 @@ class Handler extends HandlerAbstract
         $form = $context->get('form');
 
         $record = $form->getRecord();
+
         if (!$record) {
             return null;
         }
-        if ($record->hasExtension(Versioned::class) && $record->isArchived()) {
+
+        $refetched = DataObject::get_by_id($record->baseClass(), $record->ID);
+
+        // If the record was deleted, return the version still linked to the form
+        if (!$refetched && $record->hasExtension(Versioned::class)) {
             return $record;
         }
 
-        return DataObject::get_by_id($record->baseClass(), $record->ID);
+        return $refetched;
     }
 }

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -124,7 +124,7 @@ class Snapshot extends DataObject
         } else {
             // Ensure uniqueness
             foreach ($this->Items() as $item) {
-                if ($item->ObjectClass === $obj->baseClass() && $item->ObjectID === $obj->ID) {
+                if ($item->ObjectClass === $obj->baseClass() && $item->ObjectID === ($obj->ID ?: $obj->OldID)) {
                     return $this;
                 }
             }
@@ -306,7 +306,7 @@ class Snapshot extends DataObject
                 foreach ($diff->getRecords() as $obj) {
                     $item = SnapshotItem::create()
                         ->hydrateFromDataObject($obj);
-                    if ($diff->isRemoved($obj->ID)) {
+                    if ($diff->isRemoved($obj->ID ?: $obj->OldID)) {
                         $item->WasDeleted = true;
                     }
                     $eventItem->Children()->add($item);
@@ -362,7 +362,8 @@ class Snapshot extends DataObject
     public function applyOrigin(DataObject $origin): self
     {
         $this->OriginClass = $origin->baseClass();
-        $this->OriginID = $origin->ID;
+        // Handler for deleted records
+        $this->OriginID = $origin->ID ?: $origin->OldID;
         $this->addObject($origin);
 
         return $this;

--- a/src/SnapshotItem.php
+++ b/src/SnapshotItem.php
@@ -196,13 +196,15 @@ class SnapshotItem extends DataObject
      */
     public function hydrateFromDataObject(DataObject $object): self
     {
+        $objectID = (int)($object->ID ?: $object->OldID);
+
         $this->ObjectClass = $object->baseClass();
-        $this->ObjectID = (int) $object->ID;
+        $this->ObjectID = $objectID;
         $this->WasUnpublished = false;
 
         // Track versioning changes on the record if the owner is versioned
         if ($object->hasExtension(Versioned::class)) {
-            $numVersions = Versioned::get_all_versions($object->baseClass(), $object->ID)
+            $numVersions = Versioned::get_all_versions($object->baseClass(), $objectID)
                 ->count();
             $this->WasCreated = $numVersions == 1;
             $this->WasPublished = false;


### PR DESCRIPTION
Because $obj->ID is set to 0 on a deleted record, this broke the existing
snapshot creation.

Relies on https://github.com/silverstripe/silverstripe-versioned/pull/280,
without which deletions are logged as another creation.

Fixes #33