### PR TITLE
FIX: getChangedOwnership() only looks at *owned* has_one relations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
     - php: '7.3'
       env: DB=MYSQL PHPUNIT_TEST=1
 
+    - php: '7.4'
+      env: DB=MYSQL PHPUNIT_TEST=1
+
     - php: *min-version
       env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1 PHPCS_TEST=1
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7",
         "silverstripe/versioned": "^1",
-        "squizlabs/php_codesniffer": "^3"
+        "squizlabs/php_codesniffer": "^3",
+        "sminnee/phpunit-mock-objects": "^3.4.9"
     },
     "conflict": {
         "dnadesign/elemental": "< 3.2.1",


### PR DESCRIPTION
The previous code assumed that all has_one relations on an object
pointed to objects that own this object. This is a false assumption; it
also caused a bug when the has_one pointed to an unversioned object.

Fixes #36