### PR TITLE
NEW: Workflow support

### DIFF
--- a/_config/workflow.yml
+++ b/_config/workflow.yml
@@ -1,0 +1,22 @@
+---
+Name: 'snapshots-workflow'
+Only:
+  moduleexists: 'symbiote/silverstripe-advancedworkflow'
+---
+Symbiote\AdvancedWorkflow\Actions\PublishItemWorkflowAction:
+  extensions:
+    - SilverStripe\Snapshots\Workflow\WorkflowExtension
+Symbiote\AdvancedWorkflow\Jobs\WorkflowPublishTargetJob:
+   extensions:
+     - SilverStripe\Snapshots\Workflow\WorkflowExtension
+
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\EventDispatcher\Dispatch\Dispatcher:
+    properties:
+      handlers:
+        unpublish:
+          on: [ 'workflowComplete.unpublish' ]
+          handler: '%$SilverStripe\Snapshots\Handler\Form\UnpublishHandler'
+        publish:
+          on: [ 'workflowComplete.publish' ]
+          handler: '%$SilverStripe\Snapshots\Handler\Form\PublishHandler'

--- a/src/Handler/Elemental/PageSaveHandler.php
+++ b/src/Handler/Elemental/PageSaveHandler.php
@@ -32,6 +32,9 @@ class PageSaveHandler extends SaveHandler
         }
 
         $record = $this->getRecordFromContext($context);
+        if (!$record) {
+            return null;
+        }
         if (!$record->hasExtension(ElementalAreasExtension::class)) {
             return parent::createSnapshot($context);
         }

--- a/src/Workflow/WorkflowExtension.php
+++ b/src/Workflow/WorkflowExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace SilverStripe\Snapshots\Workflow;
+
+use SilverStripe\EventDispatcher\Dispatch\Dispatcher;
+use SilverStripe\EventDispatcher\Symfony\Event;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\DataObject;
+
+class WorkflowExtension extends DataExtension
+{
+    public function onAfterWorkflowPublish(DataObject $target)
+    {
+        $record = DataObject::get_by_id(get_class($target), $target->ID, false);
+        Dispatcher::singleton()->trigger('workflowComplete', new Event('publish', [
+            'record' => $record,
+        ]));
+    }
+
+    public function onAfterWorkflowUnpublish(DataObject $target)
+    {
+        $record = DataObject::get_by_id(get_class($target), $target->ID, false);
+        Dispatcher::singleton()->trigger('workflowComplete', new Event('publish', [
+            'record' => $record,
+        ]));
+    }
+
+}


### PR DESCRIPTION
This pull request adds event handlers that bind to workflow events for publish and unpublish to ensure that snapshots are created when content is published or unpublished via workflow actions.