### PR TITLE
NEW CsvBulkLoader integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Some common thirdparty modules are supported out of the box. The most notable is
 * Edit individual element
 * Save all elements via page save
 * Sort elements
+* ModelAdmin and GridField CSV imports
 
 As mentioned above, elements all receive `snapshot_relation_tracking` on their pages by default, as well.
 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -9,6 +9,9 @@ SilverStripe\Core\Injector\Injector:
 SilverStripe\Versioned\ChangeSetItem:
   extensions:
     - SilverStripe\Snapshots\SnapshotChangeSetItem
+SilverStripe\Dev\CsvBulkLoader:
+  extensions:
+    - SilverStripe\Snapshots\CsvBulkLoader\SaveListener
 ---
 Name: snapshot-migration
 ---
@@ -68,3 +71,6 @@ SilverStripe\Core\Injector\Injector:
         graphqlMutation:
           on: [ 'graphqlOperation' ]
           handler: '%$SilverStripe\Snapshots\Handler\GraphQL\Middleware\RollbackHandler'
+        csvBulkLoaderImport:
+          on: [ 'csvBulkLoaderImport' ]
+          handler: '%$SilverStripe\Snapshots\Handler\CsvBulkLoader\Handler'

--- a/src/CsvBulkLoader/SaveListener.php
+++ b/src/CsvBulkLoader/SaveListener.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace SilverStripe\Snapshots\CsvBulkLoader;
+
+use SilverStripe\EventDispatcher\Dispatch\Dispatcher;
+use SilverStripe\EventDispatcher\Symfony\Event;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\DataObject;
+
+class SaveListener extends DataExtension
+{
+    public function onAfterProcessRecord(DataObject $obj, $preview, $isChanged)
+    {
+        // No need tracking previews, since we don't expect any writes
+        if ($preview) {
+            return;
+        }
+
+        // Only record snapshot on changes.
+        // All rows from a CSV import will come through this by default.
+        if (!$isChanged) {
+            return;
+        }
+
+        Dispatcher::singleton()->trigger(
+            'csvBulkLoaderImport',
+            Event::create('import', ['obj' => $obj])
+        );
+    }
+}

--- a/src/CsvBulkLoader/SaveListener.php
+++ b/src/CsvBulkLoader/SaveListener.php
@@ -25,7 +25,7 @@ class SaveListener extends DataExtension
 
         Dispatcher::singleton()->trigger(
             'csvBulkLoaderImport',
-            Event::create('import', ['obj' => $obj])
+            Event::create(get_class($obj), ['record' => $obj])
         );
     }
 }

--- a/src/Handler/CsvBulkLoader/Handler.php
+++ b/src/Handler/CsvBulkLoader/Handler.php
@@ -19,7 +19,7 @@ class Handler extends HandlerAbstract
         $obj = $context->get('record');
 
         if (!$obj) {
-            throw new \InvalidArgumentException('Requires "obj" in context');
+            throw new \InvalidArgumentException('Requires "record" in context');
         }
 
         // Create an individual snapshot for each object to ensure they're all captured.

--- a/src/Handler/CsvBulkLoader/Handler.php
+++ b/src/Handler/CsvBulkLoader/Handler.php
@@ -16,7 +16,7 @@ class Handler extends HandlerAbstract
      */
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
-        $obj = $context->get('obj');
+        $obj = $context->get('record');
 
         if (!$obj) {
             throw new \InvalidArgumentException('Requires "obj" in context');

--- a/src/Handler/CsvBulkLoader/Handler.php
+++ b/src/Handler/CsvBulkLoader/Handler.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace SilverStripe\Snapshots\Handler\CsvBulkLoader;
+
+use SilverStripe\EventDispatcher\Event\EventContextInterface;
+use SilverStripe\Snapshots\Handler\HandlerAbstract;
+use SilverStripe\Snapshots\Snapshot;
+
+class Handler extends HandlerAbstract
+{
+    /**
+     * @param EventContextInterface $context
+     * @return Snapshot|null
+     * @throws ValidationException
+     */
+    protected function createSnapshot(EventContextInterface $context): ?Snapshot
+    {
+        $obj = $context->get('obj');
+
+        if (!$obj) {
+            throw new \InvalidArgumentException('Requires "obj" in context');
+        }
+
+        // Create an individual snapshot for each object to ensure they're all captured.
+        // Unlike a recursive publish, with imports we rely on all objects noting the action in their history.
+        // The disadvantage of this approach is that the origin of the modification (a CSV import) isn't recorded.
+        return Snapshot::singleton()->createSnapshot($obj);
+    }
+}


### PR DESCRIPTION
New snapshot for every row that's actually been created or changed.
Ideally we'd use createSnapshotEvent('CSV Import from <file>', [$objs]),
but that can be very resource intensive on bulk imports (PHP memory).
The bulk loader destroys the DataObject instances after loading them,
so we'd need to recreate them.

We could allow createSnapshot() to accept a map of "class => ID"
instead, and then recreate+destroy the DataObject instances on the fly.
For now, recording one snapshot per row is good enough.

Relies on https://github.com/silverstripe/silverstripe-framework/pull/9929