### PR TITLE
Ensure snapshot data objects not visible in File used on tab

### DIFF
--- a/_config/thirdparty.yml
+++ b/_config/thirdparty.yml
@@ -49,3 +49,12 @@ SilverStripe\Core\Injector\Injector:
         publish:
           on: [ 'embargoExpiryJob.publish' ]
           handler: '%$SilverStripe\Snapshots\Handler\Form\PublishHandler'
+# silverstripe-admin
+---
+Name: snapshots-cms-admin
+Only:
+  moduleexists: silverstripe/admin
+---
+SilverStripe\Admin\Forms\UsedOnTable:
+  extensions:
+    - SilverStripe\Snapshots\Thirdparty\UsedOnTableExtension

--- a/src/Thirdparty/UsedOnTableExtension.php
+++ b/src/Thirdparty/UsedOnTableExtension.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\Snapshots\Thirdparty;
+
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\Snapshots\Snapshot;
+use SilverStripe\Snapshots\SnapshotEvent;
+use SilverStripe\Snapshots\SnapshotItem;
+
+class UsedOnTableExtension extends DataExtension
+{
+    /**
+     * Exclude snapshot data objects from appearing in Used On tab in Files section
+     *
+     * @param array $excludedClasses
+     */
+    public function updateUsageExcludedClasses(array &$excludedClasses): void
+    {
+        $excludedClasses[] = Snapshot::class;
+        $excludedClasses[] = SnapshotItem::class;
+        $excludedClasses[] = SnapshotEvent::class;
+    }
+}


### PR DESCRIPTION
The PR includes an extension to extend class `SilverStripe\Admin\Forms\UsedOnTable` and exclude the snapshot data objects from showing in the Files section Used on Tab.

Currently, the tab looks as follows,
![Screen Shot 2021-09-24 at 9 52 56 AM](https://user-images.githubusercontent.com/166450/134589314-e4af695c-8a96-4b55-86bb-23f5febc307c.png)

