### PR TITLE
Update visiblity of two SnapshotPublishable methods

### DIFF
--- a/src/SnapshotPublishable.php
+++ b/src/SnapshotPublishable.php
@@ -207,7 +207,7 @@ class SnapshotPublishable extends RecursivePublishable
      *
      * @return array list of filters for using in ORM APIs
      */
-    private function getSnapshotsBetweenVersionsFilters($min, $max = null, $includeAll = false)
+    protected function getSnapshotsBetweenVersionsFilters($min, $max = null, $includeAll = false)
     {
         $itemTable = DataObject::getSchema()->tableName(SnapshotItem::class);
 
@@ -528,7 +528,7 @@ class SnapshotPublishable extends RecursivePublishable
      * @param DataObject $previous
      * @return array
      */
-    private function getChangedOwnership(DataObject $previous): array
+    protected function getChangedOwnership(DataObject $previous): array
     {
         $owner = $this->owner;
 


### PR DESCRIPTION
## Short version

I need to please be able to extend this class while still having access to `getSnapshotsBetweenVersionsFilters()`.

## Longer version (but still short)

We don't seem to have great support for Fluent at the moment. The query run as part of `getSnapshotsBetweenVersionsFilters()` (and `hasOwnedModifications()`) don't consider the Locale context.

I hope to have time to be able to property digest these methods and come up with some support for the module in the new year, but atm I'm between a rock and a hard place, and just need to be able to extend/replace/fix.

**Please and thank you**