### PR TITLE
NEW: Code cleanup (tests, linting).

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,11 @@
+checks:
+  php: true
+
+build:
+  nodes:
+    analysis:
+      tests:
+        override: [php-scrutinizer-run]
+
+filter:
+  paths: ["src/*", "tests/*"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,51 +1,9 @@
-language: php
-
-dist: trusty
+version: ~> 1.0
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION=dev-master
+    - COMPOSER_ROOT_VERSION="4.x-dev"
+    - REQUIRE_RECIPE="4.x-dev"
 
-matrix:
-  fast_finish: true
-  include:
-    - php: '7.2'
-      env: DB=MYSQL PHPUNIT_TEST=1
-
-    - php: '7.3'
-      env: DB=MYSQL PHPUNIT_TEST=1
-
-    - php: '7.4'
-      env: DB=MYSQL PHPUNIT_TEST=1
-
-    - php: *min-version
-      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1 PHPCS_TEST=1
-
-#    - php: *min-version
-#      env: DB=PGSQL PHPUNIT_TEST=1
-
-    - php: *min-version
-      env: DB=MYSQL PDO=1 PHPUNIT_TEST=1
-
-before_script:
-# Init PHP
-  - printf "\n" | pecl install imagick
-  - phpenv rehash
-  - phpenv config-rm xdebug.ini
-  - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-
-# Install composer
-  - composer validate
-  - composer require silverstripe/recipe-core:4.5.x-dev silverstripe/recipe-cms:4.5.x-dev dnadesign/silverstripe-elemental:4.3.x-dev --prefer-dist --no-update
-# silverstripe/recipe-cms requires versioned 1.4.x-dev
-  - composer require silverstripe/versioned:"1.5.x-dev" --prefer-dist --no-update
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --prefer-dist --no-update; fi
-  - composer install --prefer-dist
-
-script:
-  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
-  - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
-
-after_success:
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi
+import:
+  - silverstripe/silverstripe-travis-shared:config/provision/standard-jobs-fixed.yml

--- a/composer.json
+++ b/composer.json
@@ -19,18 +19,23 @@
             "homepage": "http://silverstripe.org"
         }
     ],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev",
+            "dev-1": "1.x-dev"
+        }
+    },
     "require": {
-        "php": ">=7.1.0",
-        "silverstripe/framework": "^4.5.1",
+        "php": "^7.4 || ^8",
+        "silverstripe/framework": "^4.7",
         "silverstripe/versioned": "^1",
         "silverstripe/vendor-plugin": "^1",
         "silverstripe/cms-events": "dev-master"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "silverstripe/recipe-testing": "^1 || ^2",
         "silverstripe/versioned": "^1",
-        "squizlabs/php_codesniffer": "^3",
-        "sminnee/phpunit-mock-objects": "^3.4.9"
+        "dnadesign/silverstripe-elemental": "^4"
     },
     "conflict": {
         "dnadesign/elemental": "< 3.2.1",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,24 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="SilverStripe">
-	<description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+
+    <file>src</file>
+    <file>tests</file>
 
     <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
 
-	<!-- base rules are PSR-2 -->
-	<rule ref="PSR2" >
-		<!-- Current exclusions -->
-		<exclude name="PSR1.Methods.CamelCapsMethodName" />
-		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
-		<exclude name="PSR2.Classes.PropertyDeclaration" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration" /> <!-- causes php notice while linting -->
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault" />
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment" />
-		<exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
-		<exclude name="Squiz.Scope.MethodScope" />
-		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
-		<exclude name="Generic.Files.LineLength.TooLong" />
-		<exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
-	</rule>
+    <!-- base rules are PSR-2 -->
+    <rule ref="PSR2" >
+        <!-- Current exclusions -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName" />
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+        <exclude name="PSR2.Classes.PropertyDeclaration" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration" /> <!-- causes php notice while linting -->
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault" />
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment" />
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
+        <exclude name="Squiz.Scope.MethodScope" />
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
+        <exclude name="Generic.Files.LineLength.TooLong" />
+        <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd" />
+    </rule>
 </ruleset>
-

--- a/src/ActivityEntry.php
+++ b/src/ActivityEntry.php
@@ -54,9 +54,8 @@ class ActivityEntry extends ArrayData
             // This gets all versions except for the deleted version so we just get the latest one
             /** @var DataObject|Versioned $previousVersion */
             $previousVersion = Versioned::get_all_versions($item->ObjectClass, $item->ObjectID)
-                ->filter(['WasDeleted' => 0])
                 ->sort('Version', 'DESC')
-                ->first();
+                ->find('WasDeleted', 0);
 
             if ($previousVersion && $previousVersion->exists()) {
                 $itemObj = $item->getItem($previousVersion->Version);

--- a/src/CsvBulkLoader/SaveListener.php
+++ b/src/CsvBulkLoader/SaveListener.php
@@ -1,8 +1,8 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\CsvBulkLoader;
 
+use SilverStripe\Dev\CsvBulkLoader;
 use SilverStripe\EventDispatcher\Dispatch\Dispatcher;
 use SilverStripe\EventDispatcher\Symfony\Event;
 use SilverStripe\ORM\DataExtension;
@@ -10,7 +10,14 @@ use SilverStripe\ORM\DataObject;
 
 class SaveListener extends DataExtension
 {
-    public function onAfterProcessRecord(DataObject $obj, $preview, $isChanged)
+    /**
+     * Extension point in @see CsvBulkLoader::processRecord()
+     *
+     * @param DataObject $obj
+     * @param mixed $preview
+     * @param mixed $isChanged
+     */
+    public function onAfterProcessRecord(DataObject $obj, $preview, $isChanged): void
     {
         // No need tracking previews, since we don't expect any writes
         if ($preview) {

--- a/src/Elemental/SaveListener.php
+++ b/src/Elemental/SaveListener.php
@@ -1,20 +1,25 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Elemental;
 
 use DNADesign\Elemental\Forms\ElementalAreaField;
+use Psr\Container\NotFoundExceptionInterface;
 use SilverStripe\EventDispatcher\Dispatch\Dispatcher;
 use SilverStripe\EventDispatcher\Symfony\Event;
 use SilverStripe\ORM\DataExtension;
 
 class SaveListener extends DataExtension
 {
-    public function onSaveInto(array $elements)
+    /**
+     * @param array $elements
+     * @throws NotFoundExceptionInterface
+     */
+    public function onSaveInto(array $elements): void
     {
-        /* @var ElementalAreaField $owner */
+        /** @var ElementalAreaField $owner */
         $owner = $this->getOwner();
         $page = $owner->getArea()->getOwnerPage();
+
         Dispatcher::singleton()->trigger(
             'elementalAreaUpdated',
             Event::create(

--- a/src/Handler/CMSMain/Handler.php
+++ b/src/Handler/CMSMain/Handler.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\CMSMain;
 
 use SilverStripe\CMS\Model\SiteTree;
@@ -10,7 +9,6 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\HandlerAbstract;
 use SilverStripe\Snapshots\Snapshot;
-use SilverStripe\Snapshots\SnapshotEvent;
 
 class Handler extends HandlerAbstract
 {
@@ -22,15 +20,18 @@ class Handler extends HandlerAbstract
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $action = $context->getAction();
+
         if ($action === null) {
             return null;
         }
 
-        /* @var HTTPResponse $result */
+        /** @var HTTPResponse $result */
         $result = $context->get('result');
+
         if (!$result instanceof HTTPResponse) {
             return null;
         }
+
         if ((int) $result->getStatusCode() !== 200) {
             return null;
         }

--- a/src/Handler/CsvBulkLoader/Handler.php
+++ b/src/Handler/CsvBulkLoader/Handler.php
@@ -1,9 +1,10 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\CsvBulkLoader;
 
+use InvalidArgumentException;
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\HandlerAbstract;
 use SilverStripe\Snapshots\Snapshot;
 
@@ -19,7 +20,7 @@ class Handler extends HandlerAbstract
         $obj = $context->get('record');
 
         if (!$obj) {
-            throw new \InvalidArgumentException('Requires "record" in context');
+            throw new InvalidArgumentException('Requires "record" in context');
         }
 
         // Create an individual snapshot for each object to ensure they're all captured.

--- a/src/Handler/Elemental/ArchiveElementHandler.php
+++ b/src/Handler/Elemental/ArchiveElementHandler.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\Elemental;
 
 use DNADesign\Elemental\Models\BaseElement;
@@ -8,37 +7,43 @@ use SilverStripe\EventDispatcher\Event\EventContextInterface;
 use SilverStripe\Snapshots\Handler\GraphQL\Middleware\Handler;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotHasher;
-use SilverStripe\Snapshots\SnapshotItem;
 use SilverStripe\Snapshots\SnapshotPublishable;
-use SilverStripe\Versioned\Versioned;
 
 class ArchiveElementHandler extends Handler
 {
+
     use SnapshotHasher;
 
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $action = $context->getAction();
+
         if ($action === null) {
             return null;
         }
 
         // GraphQL 4 ?? GraphQL 3
         $params = $context->get('variables') ?? $context->get('params');
+
         if (!$params) {
             return null;
         }
+
         $blockID = $params['blockId'] ?? null;
+
         if (!$blockID) {
             return null;
         }
+
         $block = BaseElement::get()->byID($blockID);
 
         // Ensure the block is gone
         if ($block) {
             return null;
         }
+
         $archivedBlock = SnapshotPublishable::get_at_last_snapshot(BaseElement::class, $blockID);
+
         if (!$archivedBlock) {
             return null;
         }

--- a/src/Handler/Elemental/CMSActionsHandler.php
+++ b/src/Handler/Elemental/CMSActionsHandler.php
@@ -1,14 +1,13 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\Elemental;
 
 use DNADesign\Elemental\Models\BaseElement;
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\HandlerAbstract;
 use SilverStripe\Snapshots\Snapshot;
-use SilverStripe\ORM\ValidationException;
 
 /**
  * Handles save, publish on individual blocks
@@ -23,21 +22,25 @@ class CMSActionsHandler extends HandlerAbstract
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $action = $context->getAction();
+
         if (!$action) {
             return null;
         }
 
         $request = $context->get('request');
+
         if (!$request) {
             return null;
         }
 
         $id = $request->param('ID');
+
         if (!$id) {
             return null;
         }
 
         $block = DataObject::get_by_id(BaseElement::class, $id);
+
         if (!$block) {
             return null;
         }

--- a/src/Handler/Elemental/CreateElementHandler.php
+++ b/src/Handler/Elemental/CreateElementHandler.php
@@ -1,34 +1,35 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\Elemental;
 
 use DNADesign\Elemental\Models\ElementalArea;
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Snapshots\Handler\GraphQL\Middleware\Handler;
 use SilverStripe\Snapshots\Snapshot;
-use SilverStripe\Snapshots\SnapshotItem;
-use SilverStripe\Snapshots\SnapshotPublishable;
 
 class CreateElementHandler extends Handler
 {
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $action = $context->getAction();
+
         if ($action === null) {
             return null;
         }
 
         // GraphQL 4 ?? GraphQL 3
         $params = $context->get('variables') ?? $context->get('params');
+
         if (!$params) {
             return null;
         }
+
         $areaID = $params['elementalAreaID'] ?? null;
+
         if (!$areaID) {
             return null;
         }
+
         $area = ElementalArea::get()->byID($areaID);
 
         if (!$area) {

--- a/src/Handler/Elemental/ModifyElementHandler.php
+++ b/src/Handler/Elemental/ModifyElementHandler.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\Elemental;
 
 use DNADesign\Elemental\Models\BaseElement;
@@ -14,21 +13,26 @@ use SilverStripe\Snapshots\SnapshotHasher;
  */
 class ModifyElementHandler extends Handler
 {
+
     use SnapshotHasher;
 
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $action = $context->getAction();
+
         if ($action === null) {
             return null;
         }
 
         // GraphQL 4 ?? GraphQL 3
         $params = $context->get('variables') ?? $context->get('params');
+
         if (!$params) {
             return null;
         }
+
         $blockID = $params['blockId'] ?? null;
+
         if (!$blockID) {
             return null;
         }
@@ -40,15 +44,19 @@ class ModifyElementHandler extends Handler
         }
 
         $snapshot = Snapshot::singleton()->createSnapshot($block);
+
         if (!$snapshot) {
             return null;
         }
+
         foreach ($snapshot->Items() as $item) {
-            // If it's the origin item, set published state.
-            if (static::hashSnapshotCompare($item->getItem(), $block)) {
-                $item->WasPublished = $action === 'PublishBlock';
-                $item->WasUnpublished = $action === 'UnpublishBlock';
+            if (!static::hashSnapshotCompare($item->getItem(), $block)) {
+                continue;
             }
+
+            // If it's the origin item, set published state.
+            $item->WasPublished = $action === 'PublishBlock';
+            $item->WasUnpublished = $action === 'UnpublishBlock';
         }
 
         return $snapshot;

--- a/src/Handler/Elemental/PageSaveHandler.php
+++ b/src/Handler/Elemental/PageSaveHandler.php
@@ -1,17 +1,17 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\Elemental;
 
+use DNADesign\Elemental\ElementalEditor;
 use DNADesign\Elemental\Extensions\ElementalAreasExtension;
 use DNADesign\Elemental\Models\BaseElement;
+use Exception;
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\Form\SaveHandler;
 use SilverStripe\Snapshots\RelationDiffer;
 use SilverStripe\Snapshots\Snapshot;
-use DNADesign\Elemental\ElementalEditor;
 use SilverStripe\Snapshots\SnapshotPublishable;
-use SilverStripe\ORM\ValidationException;
 
 /**
  * Handles elemental changes at the *page* level, e.g. one or many inline edits saved with Page form.
@@ -22,47 +22,55 @@ class PageSaveHandler extends SaveHandler
      * @param EventContextInterface $context
      * @return Snapshot|null
      * @throws ValidationException
+     * @throws Exception
      */
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         // Wonky check for elemental 4.
         // Elemental < 4 should leave this to the standard page save, which is a separate handler.
         if (class_exists(ElementalEditor::class)) {
+            // This is also the reason why we need Elemental 4 as a require-dev dependency
             return null;
         }
 
         $record = $this->getRecordFromContext($context);
+
         if (!$record) {
             return null;
         }
+
         if (!$record->hasExtension(ElementalAreasExtension::class)) {
             return parent::createSnapshot($context);
         }
+
         $changedElements = [];
-        /* @var SnapshotPublishable|ElementalAreasExtension $record */
+
+        /** @var SnapshotPublishable|ElementalAreasExtension $record */
         foreach ($record->getElementalRelations() as $areaName) {
             $diffs = $record->$areaName()->getRelationDiffs();
-            $elementDiffs = array_filter($diffs, function (RelationDiffer $diff) {
+            $elementDiffs = array_filter($diffs, static function (RelationDiffer $diff) {
                 return $diff->getRelationClass() === BaseElement::class;
             });
-            if (!empty($elementDiffs)) {
-                /* @var RelationDiffer $diff */
-                foreach ($elementDiffs as $diff) {
-                    $changedElements = array_merge($changedElements, $diff->getChanged());
-                }
+
+            /** @var RelationDiffer $diff */
+            foreach ($elementDiffs as $diff) {
+                $changedElements = array_merge($changedElements, $diff->getChanged());
             }
         }
+
         // Defer to page save
-        if (empty($changedElements)) {
+        if (count($changedElements) === 0) {
             return parent::createSnapshot($context);
         }
+
         $elements = BaseElement::get()->byIDs($changedElements);
+
         if (count($changedElements) === 1) {
             return Snapshot::singleton()->createSnapshot($elements->first());
         }
 
         $message = _t(
-            __CLASS__ . '.BLOCK_UPDATED_MANY',
+            self::class . '.BLOCK_UPDATED_MANY',
             'Updated {count} {type}',
             [
                 'count' => count($changedElements),
@@ -70,6 +78,7 @@ class PageSaveHandler extends SaveHandler
             ]
         );
         $snapshot = Snapshot::singleton()->createSnapshotEvent($message);
+
         foreach ($elements as $e) {
             $snapshot->addOwnershipChain($e);
         }

--- a/src/Handler/Elemental/SortElementsHandler.php
+++ b/src/Handler/Elemental/SortElementsHandler.php
@@ -1,43 +1,55 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\Elemental;
 
 use DNADesign\Elemental\Models\BaseElement;
-use DNADesign\Elemental\Models\ElementalArea;
+use Exception;
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
-use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\GraphQL\Middleware\Handler;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotPublishable;
 
 class SortElementsHandler extends Handler
 {
+    /**
+     * @param EventContextInterface $context
+     * @return Snapshot|null
+     * @throws ValidationException
+     * @throws Exception
+     */
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $action = $context->getAction();
+
         if ($action === null) {
             return null;
         }
+
         // GraphQL 4 ?? GraphQL 3
         $params = $context->get('variables') ?? $context->get('params');
+
         if (!$params) {
             return null;
         }
+
         $blockID = $params['blockId'] ?? null;
+
         if (!$blockID) {
             return null;
         }
-        /* @var SnapshotPublishable $block */
+
+        /** @var BaseElement|SnapshotPublishable $block */
         $block = BaseElement::get()->byID($blockID);
+
         if (!$block) {
             return null;
         }
 
         $area = $block->Parent();
 
-        return Snapshot::singleton()->createSnapshotEvent(
-            _t(__CLASS__ . '.REORDER_BLOCKS', 'Reordered blocks')
-        )->addOwnershipChain($area);
+        return Snapshot::singleton()
+            ->createSnapshotEvent(_t(self::class . '.REORDER_BLOCKS', 'Reordered blocks'))
+            ->addOwnershipChain($area);
     }
 }

--- a/src/Handler/Form/Handler.php
+++ b/src/Handler/Form/Handler.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\Form;
 
 use SilverStripe\Control\HTTPRequest;
@@ -22,6 +21,7 @@ class Handler extends HandlerAbstract
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $action = $context->getAction();
+
         if ($action === null) {
             return null;
         }
@@ -35,8 +35,6 @@ class Handler extends HandlerAbstract
         return Snapshot::singleton()->createSnapshot($record);
     }
 
-
-
     /**
      * @param EventContextInterface $context
      * @return DataObject|null
@@ -44,18 +42,20 @@ class Handler extends HandlerAbstract
     protected function getPageFromContext(EventContextInterface $context): ?DataObject
     {
         $page = $context->get('page');
+
         if ($page) {
             return $page;
         }
 
-        /* @var HTTPRequest $request */
+        /** @var HTTPRequest $request */
         $request = $context->get('request');
 
-        if (!$request || !$request instanceof HTTPRequest) {
+        if (!$request instanceof HTTPRequest) {
             return null;
         }
 
         $url = $request->getURL();
+
         return $this->getCurrentPageFromRequestUrl($url);
     }
 
@@ -66,6 +66,7 @@ class Handler extends HandlerAbstract
     protected function getRecordFromContext(EventContextInterface $context): ?DataObject
     {
         $record = $context->get('record');
+
         if ($record) {
             return $record;
         }
@@ -79,13 +80,13 @@ class Handler extends HandlerAbstract
             return null;
         }
 
-        $refetched = DataObject::get_by_id($record->baseClass(), $record->ID);
+        $reFetched = DataObject::get_by_id($record->baseClass(), $record->ID);
 
         // If the record was deleted, return the version still linked to the form
-        if (!$refetched && $record->hasExtension(Versioned::class)) {
+        if (!$reFetched && $record->hasExtension(Versioned::class)) {
             return $record;
         }
 
-        return $refetched;
+        return $reFetched;
     }
 }

--- a/src/Handler/Form/PublishHandler.php
+++ b/src/Handler/Form/PublishHandler.php
@@ -37,10 +37,11 @@ class PublishHandler extends Handler
 
         // Get the most recent change set to find out what was published
         /** @var ChangeSet $changeSet */
-        $changeSet = ChangeSet::get()->filter([
-            'State' => ChangeSet::STATE_PUBLISHED,
-            'IsInferred' => true,
-        ])
+        $changeSet = ChangeSet::get()
+            ->filter([
+                'State' => ChangeSet::STATE_PUBLISHED,
+                'IsInferred' => true,
+            ])
             ->sort('Created', 'DESC')
             ->first();
 

--- a/src/Handler/Form/SaveHandler.php
+++ b/src/Handler/Form/SaveHandler.php
@@ -1,10 +1,9 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\Form;
 
+use Exception;
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
-use SilverStripe\Forms\Form;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Snapshot;
@@ -18,11 +17,13 @@ class SaveHandler extends Handler
      * @param EventContextInterface $context
      * @return Snapshot|null
      * @throws ValidationException
+     * @throws Exception
      */
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
-        /* @var SnapshotPublishable|DataObject $record */
+        /** @var SnapshotPublishable|DataObject $record */
         $record = $this->getRecordFromContext($context);
+
         if ($record === null) {
             return parent::createSnapshot($context);
         }

--- a/src/Handler/Form/UnpublishHandler.php
+++ b/src/Handler/Form/UnpublishHandler.php
@@ -1,32 +1,37 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\Form;
 
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
-use SilverStripe\Forms\Form;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotHasher;
 
 class UnpublishHandler extends Handler
 {
+
     use SnapshotHasher;
 
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $snapshot = parent::createSnapshot($context);
+
         if (!$snapshot) {
             return null;
         }
+
         $record = $this->getRecordFromContext($context);
+
         if (!$record) {
             return null;
         }
+
         foreach ($snapshot->Items() as $item) {
-            // If it's the origin item, set published state.
-            if (static::hashSnapshotCompare($item->getItem(), $record)) {
-                $item->WasUnpublished = true;
+            if (!static::hashSnapshotCompare($item->getItem(), $record)) {
+                continue;
             }
+
+            // If it's the origin item, set published state.
+            $item->WasUnpublished = true;
         }
 
         return $snapshot;

--- a/src/Handler/GraphQL/Middleware/Handler.php
+++ b/src/Handler/GraphQL/Middleware/Handler.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\GraphQL\Middleware;
 
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
@@ -18,6 +17,7 @@ class Handler extends HandlerAbstract
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $action = $context->getAction();
+
         if ($action === null) {
             return null;
         }

--- a/src/Handler/GraphQL/Mutation/Handler.php
+++ b/src/Handler/GraphQL/Mutation/Handler.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\GraphQL\Mutation;
 
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
@@ -20,6 +19,7 @@ class Handler extends HandlerAbstract
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $type = $context->getAction();
+
         if ($type === null) {
             return null;
         }

--- a/src/Handler/GridField/Action/Handler.php
+++ b/src/Handler/GridField/Action/Handler.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\GridField\Action;
 
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
@@ -20,15 +19,18 @@ class Handler extends HandlerAbstract
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $action = $context->getAction();
+
         if ($action === null) {
             return null;
         }
+
         $grid = $context->get('gridField');
+
         if (!$grid) {
             return null;
         }
 
-        /* @var Form $form */
+        /** @var Form $form */
         $form = $grid->getForm();
 
         if (!$form) {

--- a/src/Handler/GridField/Action/ReorderHandler.php
+++ b/src/Handler/GridField/Action/ReorderHandler.php
@@ -4,33 +4,42 @@ namespace SilverStripe\Snapshots\Handler\GridField\Action;
 
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotEvent;
 
 class ReorderHandler extends Handler
 {
+    /**
+     * @throws ValidationException
+     */
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $snapshot = parent::createSnapshot($context);
+
         if (!$snapshot) {
             return null;
         }
-        /* @var GridField $grid */
+
+        /** @var GridField $grid */
         $grid = $context->get('gridField');
+
         if (!$grid) {
             return null;
         }
+
         $model = $grid->getModelClass();
-        $pluralName = $model::singleton()->i18n_plural_name();
+        $pluralName = DataObject::singleton($model)->i18n_plural_name();
         $event = SnapshotEvent::create([
             'Title' => _t(
-                __CLASS__ . '.REORDER_ROWS',
+                self::class . '.REORDER_ROWS',
                 'Reordered {title}',
                 ['title' => $pluralName]
             ),
         ]);
         $event->write();
-        return $snapshot
-            ->applyOrigin($event);
+
+        return $snapshot->applyOrigin($event);
     }
 }

--- a/src/Handler/GridField/Alteration/Handler.php
+++ b/src/Handler/GridField/Alteration/Handler.php
@@ -1,16 +1,13 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler\GridField\Alteration;
 
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
-use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\HandlerAbstract;
 use SilverStripe\Snapshots\Snapshot;
-use SilverStripe\Snapshots\SnapshotPublishable;
 use SilverStripe\Versioned\Versioned;
 
 class Handler extends HandlerAbstract
@@ -23,26 +20,34 @@ class Handler extends HandlerAbstract
     protected function createSnapshot(EventContextInterface $context): ?Snapshot
     {
         $action = $context->getAction();
+
         if ($action === null) {
             return null;
         }
+
         $args = $context->get('args');
+
         if (!$args) {
             return null;
         }
+
         // Warning: this relies on convention. There's no guarantee an action provider uses
         // "RecordID" as its argument name.
         $recordID = $args['RecordID'] ?? null;
+
         if ($recordID === null) {
             return null;
         }
 
-        /* @var GridField $grid */
+        /** @var GridField $grid */
         $grid = $context->get('gridField');
+
         if (!$grid) {
             return null;
         }
+
         $class = $grid->getModelClass();
+
         if (!is_subclass_of($class, DataObject::class)) {
             return null;
         }
@@ -53,8 +58,10 @@ class Handler extends HandlerAbstract
 
         $record = DataObject::get_by_id($class, $recordID);
         // @todo Move this to a proper archive handler
+
         if (!$record) {
             $record = $this->getDeletedVersion($class, $recordID);
+
             if (!$record) {
                 return null;
             }

--- a/src/Handler/HandlerAbstract.php
+++ b/src/Handler/HandlerAbstract.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Handler;
 
 use SilverStripe\Core\Config\Configurable;
@@ -8,11 +7,13 @@ use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
 use SilverStripe\EventDispatcher\Event\EventHandlerInterface;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Versioned\Versioned;
 
 abstract class HandlerAbstract implements EventHandlerInterface
 {
+
     use Configurable;
     use Injectable;
 
@@ -41,11 +42,13 @@ abstract class HandlerAbstract implements EventHandlerInterface
     protected function getMessage(string $action): string
     {
         $messages = $this->config()->get('messages');
+
         if (isset($messages[$action])) {
             return $messages[$action];
         }
 
         $key = static::class . '.HANDLER_' . $action;
+
         return _t($key, $action);
     }
 
@@ -60,12 +63,19 @@ abstract class HandlerAbstract implements EventHandlerInterface
             ->byID($id);
     }
 
+    /**
+     * @param EventContextInterface $context
+     * @throws ValidationException
+     */
     public function fire(EventContextInterface $context): void
     {
         $snapshot = $this->createSnapshot($context);
-        if ($snapshot) {
-            $snapshot->write();
+
+        if (!$snapshot) {
+            return;
         }
+
+        $snapshot->write();
     }
 
     /**
@@ -86,7 +96,6 @@ abstract class HandlerAbstract implements EventHandlerInterface
     {
         return $this->pageContextProvider;
     }
-
 
     /**
      * @param EventContextInterface $context

--- a/src/InvalidSnapshotException.php
+++ b/src/InvalidSnapshotException.php
@@ -7,7 +7,7 @@ use Throwable;
 
 class InvalidSnapshotException extends RuntimeException
 {
-    public function __construct($snapshot = "", $code = 0, Throwable $previous = null)
+    public function __construct($snapshot = '', $code = 0, Throwable $previous = null)
     {
         parent::__construct(sprintf('Invalid snapshot: %s', $snapshot), $code, $previous);
     }

--- a/src/Migration/Job.php
+++ b/src/Migration/Job.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Migration;
 
 use SilverStripe\Core\Environment;
@@ -26,9 +25,10 @@ class Job extends AbstractQueuedJob
     /**
      * @return void
      */
-    public function setup()
+    public function setup(): void
     {
         parent::setup();
+
         Environment::increaseTimeLimitTo();
         $this->addMessage('Prepping database...');
         $this->getMigrator()->setup();
@@ -40,9 +40,9 @@ class Job extends AbstractQueuedJob
     /**
      * @return string
      */
-    public function getSignature()
+    public function getSignature(): string
     {
-        return md5(get_class($this));
+        return md5(static::class);
     }
 
     /**
@@ -52,23 +52,23 @@ class Job extends AbstractQueuedJob
     {
         $remainingChildren = $this->classesToProcess;
         $this->addMessage(sizeof($remainingChildren) . ' classes remaining');
-        if (empty($remainingChildren)) {
+
+        if (count($remainingChildren) === 0) {
             $this->isComplete = true;
+
             return;
         }
+
         $baseClass = array_shift($remainingChildren);
-        $this->addMessage("Migrating $baseClass");
+        $this->addMessage('Migrating ' . $baseClass);
         $rows = $this->getMigrator()->migrate($baseClass);
-        $this->addMessage("Base ID " . $this->getMigrator()->getBaseID());
-        $this->addMessage("Migrated $rows records");
+        $this->addMessage('Base ID ' . $this->getMigrator()->getBaseID());
+        $this->addMessage(sprintf('Migrated %d records', $rows));
 
         $this->classesToProcess = $remainingChildren;
-        $this->currentStep++;
+        $this->currentStep += 1;
     }
 
-    /**
-     * @return void
-     */
     public function afterComplete(): void
     {
         parent::afterComplete();
@@ -81,15 +81,12 @@ class Job extends AbstractQueuedJob
     /**
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
-        return _t(__CLASS__ . '.MIGRATE', 'Migrate versions tables to snapshots');
+        return _t(self::class . '.MIGRATE', 'Migrate versions tables to snapshots');
     }
 
-    /**
-     * @return string
-     */
-    public function getJobType()
+    public function getJobType(): int
     {
         return QueuedJob::QUEUED;
     }
@@ -98,7 +95,7 @@ class Job extends AbstractQueuedJob
      * @param MigrationService $migrator
      * @return $this
      */
-    public function setMigrator(MigrationService $migrator)
+    public function setMigrator(MigrationService $migrator): self
     {
         $this->migrator = $migrator;
 

--- a/src/Migration/MigrationService.php
+++ b/src/Migration/MigrationService.php
@@ -1,10 +1,10 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Migration;
 
+use Exception;
+use ReflectionException;
 use SilverStripe\Core\ClassInfo;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
@@ -14,10 +14,10 @@ use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotEvent;
 use SilverStripe\Snapshots\SnapshotItem;
 use SilverStripe\Versioned\Versioned;
-use ReflectionException;
 
 class MigrationService
 {
+
     use Injectable;
 
     /**
@@ -47,6 +47,7 @@ class MigrationService
 
     /**
      * MigrationService constructor.
+     *
      * @throws ReflectionException
      */
     public function __construct()
@@ -62,8 +63,7 @@ class MigrationService
      */
     public function migrate(string $baseClass): int
     {
-        /* @var DataObject $sng */
-        $sng = $baseClass::singleton();
+        $sng = DataObject::singleton($baseClass);
         $baseTable = $sng->baseTable();
         $versionsTable = $baseTable . '_Versions';
         $rows = $this->migrateSnapshots($versionsTable);
@@ -81,14 +81,17 @@ class MigrationService
      *
      * @throws ReflectionException
      * @throws ValidationException
+     * @throws Exception
      */
     public function seedRelationTracking(): void
     {
         foreach (ClassInfo::subclassesFor(DataObject::class, false) as $class) {
             $tracking = $class::config()->uninherited('snapshot_relation_tracking');
-            if (empty($tracking)) {
+
+            if (!$tracking) {
                 continue;
             }
+
             foreach ($class::get() as $record) {
                 SnapshotItem::create()
                     ->hydrateFromDataObject($record)
@@ -214,7 +217,7 @@ SQL;
         return (int) DB::affected_rows();
     }
 
-    private function createTemporaryTable()
+    private function createTemporaryTable(): void
     {
         DB::query("DROP TABLE IF EXISTS \"__ClassNameLookup\"");
         DB::create_table(
@@ -225,6 +228,7 @@ SQL;
             ]
         );
         $lines = [];
+
         foreach ($this->getClassMap() as $className => $baseClassName) {
             $lines[] = sprintf(
                 "('%s', '%s')",
@@ -232,6 +236,7 @@ SQL;
                 $this->sanitiseClassName($baseClassName)
             );
         }
+
         $values = implode(",\n", $lines);
         $query = <<<SQL
             INSERT INTO "__ClassNameLookup"
@@ -264,8 +269,10 @@ SQL;
     private function generateClassMap(): void
     {
         $map = [];
+
         foreach (ClassInfo::subclassesFor(DataObject::class, false) as $class) {
             $sng = Injector::inst()->get($class);
+
             if (!$sng->hasExtension(Versioned::class)) {
                 continue;
             }
@@ -273,19 +280,20 @@ SQL;
             $baseClass = $sng->baseClass();
             $map[$class] = $baseClass;
         }
+
         $this->classMap = $map;
     }
 
     /**
-     * @param $class
+     * @param string $class
      * @return string
      */
-    private function sanitiseClassName($class): string
+    private function sanitiseClassName(string $class): string
     {
         return str_replace('\\', '\\\\', $class);
     }
 
-    public function getBaseID()
+    public function getBaseID(): int
     {
         return $this->baseID;
     }

--- a/src/Migration/Task.php
+++ b/src/Migration/Task.php
@@ -1,15 +1,18 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Migration;
 
 use Psr\Log\LoggerInterface;
-use SilverStripe\Control\HTTPRequest;
+use ReflectionException;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
+use SilverStripe\ORM\ValidationException;
 
 class Task extends BuildTask
 {
+    /**
+     * @var string
+     */
     private static $segment = 'snapshot-migration';
 
     /**
@@ -24,6 +27,7 @@ class Task extends BuildTask
 
     /**
      * MigrationTask constructor.
+     *
      * @param MigrationService $service
      */
     public function __construct(MigrationService $service)
@@ -33,9 +37,11 @@ class Task extends BuildTask
     }
 
     /**
-     * @param HTTPRequest $request
+     * @param mixed $request
+     * @throws ReflectionException
+     * @throws ValidationException
      */
-    public function run($request)
+    public function run($request): void
     {
         $logger = Injector::inst()->get(LoggerInterface::class);
 
@@ -45,10 +51,11 @@ class Task extends BuildTask
         $logger->info('Migrating ' . sizeof($classes) . ' classes');
 
         foreach ($classes as $class) {
-            $logger->info("Migrating $class");
+            $logger->info('Migrating ' . $class);
             $rows = $this->migrator->migrate($class);
-            $logger->info("$rows records migrated");
+            $logger->info($rows . ' records migrated');
         }
+
         $this->migrator->seedRelationTracking();
         $this->migrator->tearDown();
     }

--- a/src/PageContextProvider.php
+++ b/src/PageContextProvider.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Snapshots\Handler;
 
-use Page;
 use SilverStripe\Admin\AdminRootController;
 use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\CMS\Controllers\CMSPageEditController;
@@ -22,6 +21,7 @@ use SilverStripe\ORM\DataObject;
  */
 class PageContextProvider
 {
+
     use Injectable;
 
     /**
@@ -43,7 +43,7 @@ class PageContextProvider
      */
     public function getCurrentPageFromController($controller): ?DataObject
     {
-        while ($controller && ($controller instanceof Form || $controller instanceof GridFieldDetailForm_ItemRequest)) {
+        while ($controller instanceof Form || $controller instanceof GridFieldDetailForm_ItemRequest) {
             $controller = $controller->getController();
         }
 
@@ -57,7 +57,7 @@ class PageContextProvider
 
         $page = $controller->currentPage();
 
-        if ($page === null || !$page instanceof SiteTree) {
+        if (!$page instanceof SiteTree) {
             return null;
         }
 
@@ -74,6 +74,7 @@ class PageContextProvider
     public function getCurrentPageFromRequestUrl(?string $url): ?SiteTree
     {
         $url = trim($url, '/ ');
+
         if (!$url) {
             return null;
         }
@@ -84,9 +85,11 @@ class PageContextProvider
         $urlBase = $controller->config()->get('url_segment');
         $baseURL = Path::join($adminSegment, $urlBase);
         $pattern = '#^' . $baseURL .'#';
+
         if (!preg_match($pattern, $url)) {
             return null;
         }
+
         $slug = preg_replace($pattern, '', $url);
         $request = new HTTPRequest('GET', $slug);
         $params = $request->match($controller->config()->get('url_rule'));
@@ -98,9 +101,11 @@ class PageContextProvider
 
         // find page by ID
         $page = DataObject::get_by_id(SiteTree::class, (int) $pageId);
+
         if (!$page) {
             return null;
         }
+
         // re-fetch the page with proper type
         $page = DataObject::get_by_id($page->ClassName, $pageId);
 
@@ -120,7 +125,9 @@ class PageContextProvider
             return $this->request;
         }
 
-        return Controller::has_curr() ? Controller::curr()->getRequest() : null;
+        return Controller::has_curr()
+            ? Controller::curr()->getRequest()
+            : null;
     }
 
     /**
@@ -140,12 +147,15 @@ class PageContextProvider
     public function getPageFromReferrer(): ?SiteTree
     {
         $request = $this->getRequest();
+
         if (!$request) {
             return null;
         }
+
         $url = $request->getHeader('referer');
         $url = parse_url($url, PHP_URL_PATH);
         $url = ltrim($url, '/');
+
         return $this->getCurrentPageFromRequestUrl($url);
     }
 }

--- a/src/RelationDiffer.php
+++ b/src/RelationDiffer.php
@@ -1,12 +1,11 @@
 <?php
 
-
 namespace SilverStripe\Snapshots;
 
+use InvalidArgumentException;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
-use InvalidArgumentException;
 
 class RelationDiffer
 {
@@ -49,6 +48,7 @@ class RelationDiffer
 
     /**
      * RelationDiffer constructor.
+     *
      * @var string $relationClass
      * @var string $relationTypes
      * @var array $previousVersionMapping
@@ -63,9 +63,13 @@ class RelationDiffer
         if (!is_subclass_of($relationClass, DataObject::class)) {
             throw new InvalidArgumentException(sprintf('%s is not a DataObject', $relationClass));
         }
+
         if (!$relationClass::singleton()->hasExtension(SnapshotPublishable::class)) {
-            throw new InvalidArgumentException(sprintf('DataObject must use the %s extension', SnapshotPublishable::class));
+            throw new InvalidArgumentException(
+                sprintf('DataObject must use the %s extension', SnapshotPublishable::class)
+            );
         }
+
         $this->relationClass = $relationClass;
         $this->relationType = $relationType;
         $this->previousVersionMapping = $previousVersionMapping;
@@ -91,11 +95,14 @@ class RelationDiffer
             if (!isset($this->currentVersionMapping[$prevID])) {
                 continue;
             }
+
             $currentVersion = $this->currentVersionMapping[$prevID];
+
             // Versioned extension not applied
             if ($prevVersion === null && $currentVersion === null) {
                 continue;
             }
+
             // New version is higher than old version. It's a change.
             if ($currentVersion > $prevVersion) {
                 $changed[] = $prevID;
@@ -110,7 +117,7 @@ class RelationDiffer
      */
     public function hasChanges(): bool
     {
-        return !empty($this->added) || !empty($this->removed) || !empty($this->changed);
+        return count($this->added) > 0 || count($this->removed) > 0 || count($this->changed) > 0;
     }
 
     /**
@@ -121,11 +128,13 @@ class RelationDiffer
         if (!$this->hasChanges()) {
             return [];
         }
+
         $ids = array_merge(
             $this->added,
             $this->removed,
             $this->changed
         );
+
         return DataList::create($this->relationClass)->byIDs($ids)->toArray();
     }
 

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -97,11 +97,7 @@ class Snapshot extends DataObject
      */
     public function getOriginItem(): ?DataObject
     {
-        $item = $this->Items()
-            ->filter([
-                'ObjectHash' => $this->OriginHash,
-            ])
-            ->first();
+        $item = $this->Items()->find('ObjectHash', $this->OriginHash);
 
         if ($item instanceof DataObject) {
             return $item;

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Snapshots;
 
+use Exception;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\ORM\Queries\SQLSelect;
@@ -10,7 +11,6 @@ use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
 use SilverStripe\Versioned\Versioned;
-use Exception;
 
 /**
  * Class Snapshot
@@ -95,22 +95,31 @@ class Snapshot extends DataObject
     /**
      * @return SnapshotItem|null
      */
-    public function getOriginItem()
+    public function getOriginItem(): ?DataObject
     {
-        return $this->Items()->filter([
-            'ObjectHash' => $this->OriginHash,
-        ])->first();
+        $item = $this->Items()
+            ->filter([
+                'ObjectHash' => $this->OriginHash,
+            ])
+            ->first();
+
+        if ($item instanceof DataObject) {
+            return $item;
+        }
+
+        return null;
     }
 
     /**
-     * Shortcut for adding items by their associated dataobjects
+     * Shortcut for adding items by their associated data objects
+     *
      * @param DataObject $obj
      * @return $this
      * @throws Exception
      */
     public function addObject(DataObject $obj): self
     {
-        if ($this->Items()->count() >= $this->config()->item_limit) {
+        if ($this->Items()->count() >= $this->config()->get('item_limit')) {
             return $this;
         }
 
@@ -120,6 +129,7 @@ class Snapshot extends DataObject
                     return $this;
                 }
             }
+
             $this->Items()->add($obj);
         } else {
             // Ensure uniqueness
@@ -128,6 +138,7 @@ class Snapshot extends DataObject
                     return $this;
                 }
             }
+
             $item = SnapshotItem::create()
                 ->hydrateFromDataObject($obj);
 
@@ -138,11 +149,12 @@ class Snapshot extends DataObject
     }
 
     /**
-     * @return SnapshotItem|null
+     * @return DataObject|null
      */
-    public function getOriginVersion()
+    public function getOriginVersion(): ?DataObject
     {
         $originItem = $this->getOriginItem();
+
         if ($originItem) {
             return Versioned::get_version(
                 $originItem->ObjectClass,
@@ -157,20 +169,23 @@ class Snapshot extends DataObject
     /**
      * @return string
      */
-    public function getDate()
+    public function getDate(): string
     {
         return $this->LastEdited;
     }
 
     /**
      * @return string
+     * @throws Exception
      */
     public function getActivityDescription(): string
     {
+        /** @var SnapshotItem $item */
         $item = $this->getOriginItem();
+
         return $item
             ? ActivityEntry::createFromSnapshotItem($item)->getDescription()
-            : _t(__CLASS__ . 'ACTIVITY_NONE', 'none');
+            : _t(self::class . 'ACTIVITY_NONE', 'none');
     }
 
     public function getActivityAgo(): string
@@ -184,8 +199,10 @@ class Snapshot extends DataObject
     public function getIsLiveSnapshot(): bool
     {
         $table = DataObject::getSchema()->tableName(SnapshotItem::class);
-        /* @var Versioned|DataObject $originVersion */
+
+        /** @var Versioned|DataObject $originVersion */
         $originVersion = $this->getOriginVersion();
+
         if (!$originVersion) {
             return false;
         }
@@ -193,16 +210,18 @@ class Snapshot extends DataObject
         if ($originVersion->hasStages() && !$originVersion->isLiveVersion()) {
             return false;
         }
+
         $liveVersionNumber = SnapshotPublishable::get_published_version_number(
             $originVersion->baseClass(),
             $originVersion->ID
         );
+
         $latestPublishID = SQLSelect::create()
             ->setSelect('MAX("SnapshotID")')
-            ->setFrom($table)
+            ->setFrom("\"$table\"")
             ->addWhere([
-                '"Version" = ?' => $liveVersionNumber,
-                '"ObjectHash" = ?' => static::hashObjectForSnapshot($originVersion),
+                "\"$table\".\"Version\" = ?" => $liveVersionNumber,
+                "\"$table\".\"ObjectHash\" = ?" => static::hashObjectForSnapshot($originVersion),
             ])
             ->execute()
             ->value();
@@ -216,7 +235,9 @@ class Snapshot extends DataObject
      */
     public function getActivityType(): ?string
     {
+        /** @var SnapshotItem $item */
         $item = $this->getOriginItem();
+
         return $item
             ? ActivityEntry::createFromSnapshotItem($item)->Action
             : null;
@@ -262,7 +283,7 @@ class Snapshot extends DataObject
         return true;
     }
 
-    public function onBeforeWrite()
+    public function onBeforeWrite(): void
     {
         parent::onBeforeWrite();
 
@@ -270,16 +291,17 @@ class Snapshot extends DataObject
     }
 
     /**
-     *
      * @param DataObject|null $origin
      * @param array $extraObjects
      * @return Snapshot|null
      * @throws ValidationException
+     * @throws Exception
      */
     public function createSnapshot(
         DataObject $origin,
         array $extraObjects = []
     ): ?Snapshot {
+        /** @var DataObject|SnapshotPublishable $origin */
         if (!$origin->hasExtension(SnapshotPublishable::class)) {
             return null;
         }
@@ -301,14 +323,17 @@ class Snapshot extends DataObject
             $event->write();
             $snapshot->applyOrigin($event);
             $eventItem = $snapshot->getOriginItem();
-            /* @var RelationDiffer $diff */
+
+            /** @var RelationDiffer $diff */
             foreach ($diffs as $diff) {
                 foreach ($diff->getRecords() as $obj) {
                     $item = SnapshotItem::create()
                         ->hydrateFromDataObject($obj);
+
                     if ($diff->isRemoved($obj->ID ?: $obj->OldID)) {
                         $item->WasDeleted = true;
                     }
+
                     $eventItem->Children()->add($item);
                     $snapshot->addObject($item);
                 }
@@ -330,7 +355,7 @@ class Snapshot extends DataObject
      * @return Snapshot
      * @throws ValidationException
      */
-    public function createSnapshotEvent(string $message, $extraObjects = []): Snapshot
+    public function createSnapshotEvent(string $message, array $extraObjects = []): Snapshot
     {
         $event = SnapshotEvent::create([
             'Title' => $message,
@@ -344,10 +369,13 @@ class Snapshot extends DataObject
      * sets the related snapshot items to not modified
      *
      * items with modifications are used to determine the owner's modification
-     * status (eg in site tree's status flags)
+     * status (e.g. in site tree's status flags)
+     *
+     * @throws ValidationException
      */
     public function markNoModifications(): void
     {
+        /** @var SnapshotItem $item */
         foreach ($this->Items() as $item) {
             $item->Modification = false;
             $item->write();
@@ -377,6 +405,7 @@ class Snapshot extends DataObject
     public function addOwnershipChain(DataObject $obj): self
     {
         $this->addObject($obj);
+
         foreach ($obj->getIntermediaryObjects() as $o) {
             $this->addObject($o);
         }

--- a/src/SnapshotChangeSetItem.php
+++ b/src/SnapshotChangeSetItem.php
@@ -1,30 +1,40 @@
 <?php
 
-
 namespace SilverStripe\Snapshots;
 
+use Exception;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\ChangeSetItem;
-use SilverStripe\Versioned\Versioned;
 
 /**
  * Class SnapshotChangeSetItem
+ *
  * @property ChangeSetItem $owner
  */
 class SnapshotChangeSetItem extends DataExtension
 {
-    public function updateChangeType(&$type, $draftVersion, $liveVersion)
+    /**
+     * Extension point in @see ChangeSetItem::getChangeType()
+     *
+     * @param $type
+     * @param $draftVersion
+     * @param $liveVersion
+     * @throws Exception
+     */
+    public function updateChangeType(&$type, $draftVersion, $liveVersion): void
     {
-        /* @var DataObject|SnapshotPublishable $obj */
+        /** @var DataObject|SnapshotPublishable $obj */
         $obj = $this->owner->getComponent('Object');
 
         if (!$obj->hasExtension(SnapshotPublishable::class)) {
             return;
         }
 
-        if ($obj->hasOwnedModifications()) {
-            $type = ChangeSetItem::CHANGE_MODIFIED;
+        if (!$obj->hasOwnedModifications()) {
+            return;
         }
+
+        $type = ChangeSetItem::CHANGE_MODIFIED;
     }
 }

--- a/src/SnapshotHasher.php
+++ b/src/SnapshotHasher.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Snapshots;
 
-use SilverStripe\Core\ClassInfo;
 use SilverStripe\ORM\DataObject;
 
 /**
@@ -13,11 +12,11 @@ trait SnapshotHasher
     /**
      * Generates a hash for versioned snapshots
      *
-     * @param $class
-     * @param $id
+     * @param string|null $class
+     * @param int|null $id
      * @return string
      */
-    public static function hashForSnapshot($class, $id): string
+    public static function hashForSnapshot(?string $class, ?int $id): string
     {
         return md5(sprintf('%s:%s', $class, $id));
     }

--- a/src/SnapshotItem.php
+++ b/src/SnapshotItem.php
@@ -24,8 +24,10 @@ use SilverStripe\View\ArrayData;
  * @property int $SnapshotID
  * @property int $ObjectID
  * @property string $ObjectClass
+ * @property string $Modification
  * @method Snapshot Snapshot()
  * @method DataObject Object()
+ * @method SnapshotItem Parent()
  * @package SilverStripe\Snapshots
  */
 class SnapshotItem extends DataObject

--- a/src/SnapshotPublishable.php
+++ b/src/SnapshotPublishable.php
@@ -114,11 +114,8 @@ class SnapshotPublishable extends RecursivePublishable
     public static function get_last_snapshot_item(string $class, int $id): ?DataObject
     {
         return SnapshotItem::get()
-            ->filter([
-                'ObjectHash' => static::hashForSnapshot($class, $id),
-            ])
             ->sort('Created', 'DESC')
-            ->first();
+            ->find('ObjectHash', static::hashForSnapshot($class, $id));
     }
 
     /**
@@ -392,11 +389,8 @@ class SnapshotPublishable extends RecursivePublishable
     public function getPreviousSnapshotItem(): ?DataObject
     {
         return SnapshotItem::get()
-            ->filter([
-                'ObjectHash' => static::hashObjectForSnapshot($this->owner),
-            ])
             ->sort('Created', 'DESC')
-            ->first();
+            ->find('ObjectHash', static::hashObjectForSnapshot($this->owner));
     }
 
     /**
@@ -447,7 +441,8 @@ class SnapshotPublishable extends RecursivePublishable
 
     /**
      * @return RelationDiffer[]
-     * @todo Memorise / cache
+     * @throws Exception
+     * TODO Memoise / cache / enable cache once it's confirmed that this feature is needed
      */
     public function getRelationDiffs(): array
     {

--- a/src/SnapshotSiteTree.php
+++ b/src/SnapshotSiteTree.php
@@ -5,40 +5,46 @@ namespace SilverStripe\Snapshots;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormAction;
-use SilverStripe\Forms\LiteralField;
 use SilverStripe\ORM\DataExtension;
 
 class SnapshotSiteTree extends DataExtension
 {
     /**
-     * @param $flags
+     * Extension point in @see SiteTree::getStatusFlags()
+     *
+     * @param mixed $flags
      */
-    public function updateStatusFlags(&$flags)
+    public function updateStatusFlags(&$flags): void
     {
         $owner = $this->owner;
+
         if (!$owner->hasExtension(SnapshotPublishable::class)) {
             return;
         }
-        /* @var SnapshotPublishable|SiteTree $owner */
-        if ($owner->hasOwnedModifications()) {
-            $flags['modified'] = [
-                'text' => _t(SiteTree::class . '.MODIFIEDONDRAFTSHORT', 'Modified'),
-                'title' => _t(SiteTree::class . '.MODIFIEDONDRAFTHELP', 'Page has owned modifications'),
-            ];
+
+        /** @var SnapshotPublishable|SiteTree $owner */
+        if (!$owner->hasOwnedModifications()) {
+            return;
         }
+
+        $flags['modified'] = [
+            'text' => _t(SiteTree::class . '.MODIFIEDONDRAFTSHORT', 'Modified'),
+            'title' => _t(SiteTree::class . '.MODIFIEDONDRAFTHELP', 'Page has owned modifications'),
+        ];
     }
 
     /**
      * @param FieldList $actions
      */
-    public function updateCMSActions(FieldList $actions)
+    public function updateCMSActions(FieldList $actions): void
     {
         $owner = $this->owner;
+
         if (!$owner->hasExtension(SnapshotPublishable::class)) {
             return;
         }
 
-        /* @var SnapshotPublishable|SiteTree $owner */
+        /** @var SnapshotPublishable|SiteTree $owner */
         $canPublish = $owner->canPublish();
         $canEdit = $owner->canEdit();
         $hasOwned = $owner->hasOwnedModifications();
@@ -57,14 +63,19 @@ class SnapshotSiteTree extends DataExtension
                 );
             }
         }
+
         $publish = $actions->fieldByName('MajorActions.action_publish');
+
         if (!$publish) {
             return;
         }
-        if ($hasOwned && $canPublish) {
-            $publish->addExtraClass('btn-primary font-icon-rocket');
-            $publish->setTitle(_t(SiteTree::class . '.BUTTONSAVEPUBLISH', 'Publish'));
-            $publish->removeExtraClass('btn-outline-primary font-icon-tick');
+
+        if (!$hasOwned || !$canPublish) {
+            return;
         }
+
+        $publish->addExtraClass('btn-primary font-icon-rocket');
+        $publish->setTitle(_t(SiteTree::class . '.BUTTONSAVEPUBLISH', 'Publish'));
+        $publish->removeExtraClass('btn-outline-primary font-icon-tick');
     }
 }

--- a/src/Thirdparty/EmbargoExpiryExtension.php
+++ b/src/Thirdparty/EmbargoExpiryExtension.php
@@ -6,11 +6,18 @@ use SilverStripe\EventDispatcher\Dispatch\Dispatcher;
 use SilverStripe\EventDispatcher\Symfony\Event;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
+use Terraformers\EmbargoExpiry\Job\PublishTargetJob;
+use Terraformers\EmbargoExpiry\Job\UnPublishTargetJob;
 
 class EmbargoExpiryExtension extends DataExtension
 {
     const EVENT_NAME = 'embargoExpiryJob';
 
+    /**
+     * Extension point in @see PublishTargetJob::process()
+     *
+     * @param array $options
+     */
     public function afterPublishTargetJob(array $options): void
     {
         Dispatcher::singleton()->trigger(
@@ -25,6 +32,11 @@ class EmbargoExpiryExtension extends DataExtension
         );
     }
 
+    /**
+     * Extension point in @see UnPublishTargetJob::process()
+     *
+     * @param array $options
+     */
     public function afterUnPublishTargetJob(array $options): void
     {
         Dispatcher::singleton()->trigger(

--- a/src/Thirdparty/UsedOnTableExtension.php
+++ b/src/Thirdparty/UsedOnTableExtension.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Snapshots\Thirdparty;
 
+use SilverStripe\Admin\Forms\UsedOnTable;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotEvent;
@@ -11,6 +12,7 @@ class UsedOnTableExtension extends DataExtension
 {
     /**
      * Exclude snapshot data objects from appearing in Used On tab in Files section
+     * Extension point in @see UsedOnTable::usage()
      *
      * @param array $excludedClasses
      */

--- a/src/Workflow/WorkflowExtension.php
+++ b/src/Workflow/WorkflowExtension.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Workflow;
 
 use SilverStripe\EventDispatcher\Dispatch\Dispatcher;
@@ -10,7 +9,7 @@ use SilverStripe\ORM\DataObject;
 
 class WorkflowExtension extends DataExtension
 {
-    public function onAfterWorkflowPublish(DataObject $target)
+    public function onAfterWorkflowPublish(DataObject $target): void
     {
         $record = DataObject::get_by_id(get_class($target), $target->ID, false);
         Dispatcher::singleton()->trigger('workflowComplete', new Event('publish', [
@@ -18,12 +17,11 @@ class WorkflowExtension extends DataExtension
         ]));
     }
 
-    public function onAfterWorkflowUnpublish(DataObject $target)
+    public function onAfterWorkflowUnpublish(DataObject $target): void
     {
         $record = DataObject::get_by_id(get_class($target), $target->ID, false);
         Dispatcher::singleton()->trigger('workflowComplete', new Event('publish', [
             'record' => $record,
         ]));
     }
-
 }

--- a/tests/Handler/CMSMain/HandlerTest.php
+++ b/tests/Handler/CMSMain/HandlerTest.php
@@ -4,15 +4,19 @@ namespace SilverStripe\Snapshots\Tests\Handler\CMSMain;
 
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\EventDispatcher\Symfony\Event;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\CMSMain\Handler;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
 use SilverStripe\Snapshots\Tests\SnapshotTestAbstract;
 
 class HandlerTest extends SnapshotTestAbstract
 {
-    public function testHandlerDoesntFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesntFire(): void
     {
-        $handler = new Handler();
+        $handler = Handler::create();
         $this->mockSnapshot()
             ->expects($this->never())
             ->method('createSnapshotEvent');
@@ -26,7 +30,7 @@ class HandlerTest extends SnapshotTestAbstract
         $context = Event::create(
             'action',
             [
-                'result' => HTTPResponse::create('response', 400)
+                'result' => HTTPResponse::create('response', 400),
             ]
         );
         $handler->fire($context);
@@ -34,7 +38,7 @@ class HandlerTest extends SnapshotTestAbstract
         $context = Event::create(
             'action',
             [
-                'result' => HTTPResponse::create('response', 200)
+                'result' => HTTPResponse::create('response', 200),
             ]
         );
         $handler->fire($context);
@@ -50,9 +54,12 @@ class HandlerTest extends SnapshotTestAbstract
         $handler->fire($context);
     }
 
-    public function testHandlerDoesFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesFire(): void
     {
-        $handler = new Handler();
+        $handler = Handler::create();
         $this->mockSnapshot()
             ->expects($this->once())
             ->method('createSnapshotEvent');

--- a/tests/Handler/Elemental/ArchiveElementHandlerTest.php
+++ b/tests/Handler/Elemental/ArchiveElementHandlerTest.php
@@ -5,21 +5,29 @@ namespace SilverStripe\Snapshots\Tests\Handler\Elemental;
 use DNADesign\Elemental\Extensions\ElementalPageExtension;
 use DNADesign\Elemental\Models\BaseElement;
 use SilverStripe\EventDispatcher\Symfony\Event;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\Elemental\ArchiveElementHandler;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
 use SilverStripe\Snapshots\Tests\SnapshotTestAbstract;
+use SilverStripe\Versioned\Versioned;
 
 class ArchiveElementHandlerTest extends SnapshotTestAbstract
 {
-    protected function setUp()
-    {
-        parent::setUp();
-        BlockPage::add_extension(ElementalPageExtension::class);
-    }
+    /**
+     * @var array
+     */
+    protected static $required_extensions = [
+        BlockPage::class => [
+            ElementalPageExtension::class,
+        ],
+    ];
 
-    public function testHandlerDoesntFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesntFire(): void
     {
-        $handler = new ArchiveElementHandler();
+        $handler = ArchiveElementHandler::create();
         $this->mockSnapshot()
             ->expects($this->never())
             ->method('createSnapshot');
@@ -33,7 +41,7 @@ class ArchiveElementHandlerTest extends SnapshotTestAbstract
         $context = Event::create(
             'action',
             [
-                'params' => []
+                'params' => [],
             ]
         );
         $handler->fire($context);
@@ -41,7 +49,7 @@ class ArchiveElementHandlerTest extends SnapshotTestAbstract
         $context = Event::create(
             'action',
             [
-                'params' => ['blockId' => 5]
+                'params' => ['blockId' => 5],
             ]
         );
         $handler->fire($context);
@@ -49,19 +57,23 @@ class ArchiveElementHandlerTest extends SnapshotTestAbstract
         $context = Event::create(
             'action',
             [
-                'params' => ['blockId' => $id]
+                'params' => ['blockId' => $id],
             ]
         );
         $handler->fire($context);
     }
 
-    public function testHandlerDoesFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesFire(): void
     {
-        $handler = new ArchiveElementHandler();
+        $handler = ArchiveElementHandler::create();
         $this->mockSnapshot()
             ->expects($this->once())
             ->method('createSnapshot');
 
+        /** @var BaseElement|Versioned $elem */
         $elem = BaseElement::create();
         $elem->write();
         $this->createHistory($elem);
@@ -69,7 +81,7 @@ class ArchiveElementHandlerTest extends SnapshotTestAbstract
         $context = Event::create(
             'action',
             [
-                'params' => ['blockId' => $elem->ID]
+                'params' => ['blockId' => $elem->ID],
             ]
         );
         $handler->fire($context);

--- a/tests/Handler/Elemental/CMSActionsHandlerTest.php
+++ b/tests/Handler/Elemental/CMSActionsHandlerTest.php
@@ -6,20 +6,26 @@ use DNADesign\Elemental\Extensions\ElementalPageExtension;
 use DNADesign\Elemental\Models\BaseElement;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\EventDispatcher\Symfony\Event;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\Elemental\CMSActionsHandler;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
 use SilverStripe\Snapshots\Tests\SnapshotTestAbstract;
 
 class CMSActionsHandlerTest extends SnapshotTestAbstract
 {
+    /**
+     * @var array
+     */
+    protected static $required_extensions = [
+        BlockPage::class => [
+            ElementalPageExtension::class,
+        ],
+    ];
 
-    protected function setUp()
-    {
-        parent::setUp();
-        BlockPage::add_extension(ElementalPageExtension::class);
-    }
-
-    public function testHandlerDoesntFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesntFire(): void
     {
         $handler = new CMSActionsHandler();
         $this->mockSnapshot()
@@ -35,7 +41,7 @@ class CMSActionsHandlerTest extends SnapshotTestAbstract
         $context = Event::create(
             'action',
             [
-                'request' => new HTTPRequest('GET', '/')
+                'request' => new HTTPRequest('GET', '/'),
             ]
         );
         $handler->fire($context);
@@ -44,16 +50,19 @@ class CMSActionsHandlerTest extends SnapshotTestAbstract
             'action',
             [
                 'request' => (new HTTPRequest('GET', '/'))->setRouteParams([
-                    'ID' => 5
-                ])
+                    'ID' => 5,
+                ]),
             ]
         );
         $handler->fire($context);
     }
 
-    public function testHandlerDoesFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesFire(): void
     {
-        $handler = new CMSActionsHandler();
+        $handler = CMSActionsHandler::create();
         $this->mockSnapshot()
             ->expects($this->once())
             ->method('createSnapshot');

--- a/tests/Handler/Elemental/CreateElementHandlerTest.php
+++ b/tests/Handler/Elemental/CreateElementHandlerTest.php
@@ -5,22 +5,28 @@ namespace SilverStripe\Snapshots\Tests\Handler\Elemental;
 use DNADesign\Elemental\Extensions\ElementalPageExtension;
 use DNADesign\Elemental\Models\ElementalArea;
 use SilverStripe\EventDispatcher\Symfony\Event;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\Elemental\CreateElementHandler;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
 use SilverStripe\Snapshots\Tests\SnapshotTestAbstract;
 
 class CreateElementHandlerTest extends SnapshotTestAbstract
 {
+    /**
+     * @var array
+     */
+    protected static $required_extensions = [
+        BlockPage::class => [
+            ElementalPageExtension::class,
+        ],
+    ];
 
-    protected function setUp()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesntFire(): void
     {
-        parent::setUp();
-        BlockPage::add_extension(ElementalPageExtension::class);
-    }
-
-    public function testHandlerDoesntFire()
-    {
-        $handler = new CreateElementHandler();
+        $handler = CreateElementHandler::create();
         $this->mockSnapshot()
             ->expects($this->never())
             ->method('createSnapshot');
@@ -42,15 +48,18 @@ class CreateElementHandlerTest extends SnapshotTestAbstract
         $context = Event::create(
             'action',
             [
-                'params' => ['elementalAreaID' => 5]
+                'params' => ['elementalAreaID' => 5],
             ]
         );
         $handler->fire($context);
     }
 
-    public function testHandlerDoesFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesFire(): void
     {
-        $handler = new CreateElementHandler();
+        $handler = CreateElementHandler::create();
         $this->mockSnapshot()
             ->expects($this->once())
             ->method('createSnapshot');

--- a/tests/Handler/Elemental/PageSaveHandlerTest.php
+++ b/tests/Handler/Elemental/PageSaveHandlerTest.php
@@ -10,6 +10,7 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\EventDispatcher\Symfony\Event;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\Elemental\PageSaveHandler;
 use SilverStripe\Snapshots\RelationDiffer;
 use SilverStripe\Snapshots\SnapshotPublishable;
@@ -19,16 +20,21 @@ use SilverStripe\Versioned\RecursivePublishable;
 
 class PageSaveHandlerTest extends SnapshotTestAbstract
 {
-
+    /**
+     * @var array
+     */
     protected static $required_extensions = [
         BlockPage::class => [
             ElementalPageExtension::class,
-        ]
+        ],
     ];
 
-    public function testHandlerDoesntFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesntFire(): void
     {
-        $handler = new PageSaveHandler();
+        $handler = PageSaveHandler::create();
         $ext = $this->getMockBuilder(SnapshotPublishable::class)
             ->setMethods(['getRelationDiffs'])
             ->getMock();
@@ -36,13 +42,16 @@ class PageSaveHandlerTest extends SnapshotTestAbstract
             ->method('getRelationDiffs')
             ->will($this->returnValue([]));
         Injector::inst()->registerService($ext, RecursivePublishable::class);
-        $area = ElementalArea::create([
-            'OwnerClassName' => BlockPage::class,
-        ]);
+
+        $area = ElementalArea::create();
+        $area->OwnerClassName = BlockPage::class;
         $area->write();
+
+        /** @var BlockPage|ElementalPageExtension $blockPage */
         $blockPage = BlockPage::create();
         $blockPage->ElementalAreaID = $area->ID;
         $blockPage->write();
+
         $this->createHistory($blockPage);
         $this->mockSnapshot()
             ->expects($this->never())
@@ -51,22 +60,23 @@ class PageSaveHandlerTest extends SnapshotTestAbstract
             ->expects($this->never())
             ->method('createSnapshotEvent');
 
-        $form = Form::create(new Controller(), 'TestForm', FieldList::create(), FieldList::create());
+        $form = Form::create(Controller::create(), 'TestForm', FieldList::create(), FieldList::create());
         $form->loadDataFrom($blockPage);
         $context = Event::create('action', [
             'form' => $form,
         ]);
+
         $handler->fire($context);
     }
 
     /**
-     * @param $many
-     * @throws \SilverStripe\ORM\ValidationException
+     * @param bool $many
+     * @throws ValidationException
      * @dataProvider dataProvider
      */
-    public function testHandlerDoesFireMany($many)
+    public function testHandlerDoesFireMany(bool $many): void
     {
-        $handler = new PageSaveHandler();
+        $handler = PageSaveHandler::create();
         $block1 = BaseElement::create();
         $block1->write();
         $block2 = BaseElement::create();
@@ -94,10 +104,11 @@ class PageSaveHandlerTest extends SnapshotTestAbstract
         Injector::inst()->registerService($ext, RecursivePublishable::class);
 
         // Now that the mock is registered, we can create the object
-        $area = ElementalArea::create([
-            'OwnerClassName' => BlockPage::class,
-        ]);
+        $area = ElementalArea::create();
+        $area->OwnerClassName = BlockPage::class;
         $area->write();
+
+        /** @var BlockPage|ElementalPageExtension $blockPage */
         $blockPage = BlockPage::create();
         $blockPage->ElementalAreaID = $area->ID;
         $blockPage->write();
@@ -108,7 +119,7 @@ class PageSaveHandlerTest extends SnapshotTestAbstract
         // If only one, expect a standard snapshot with block1
         $mock->expects($many ? $this->never() : $this->once())
             ->method('createSnapshot')
-            ->with($this->callback(function ($sub) use ($block1) {
+            ->with($this->callback(static function ($sub) use ($block1) {
                 return $sub->ClassName === $block1->ClassName && $sub->ID = $block1->ID;
             }));
 
@@ -122,30 +133,31 @@ class PageSaveHandlerTest extends SnapshotTestAbstract
             ->method('addOwnershipChain')
             ->withConsecutive(
                 [
-                    $this->callback(function ($sub) use ($block1) {
+                    $this->callback(static function ($sub) use ($block1) {
                         return $sub->ClassName === $block1->ClassName && $sub->ID = $block1->ID;
-                    })
+                    }),
                 ],
                 [
-                    $this->callback(function ($sub) use ($block2) {
+                    $this->callback(static function ($sub) use ($block2) {
                         return $sub->ClassName === $block2->ClassName && $sub->ID = $block2->ID;
-                    })
+                    }),
                 ]
             );
 
-        $form = Form::create(new Controller(), 'TestForm', FieldList::create(), FieldList::create());
+        $form = Form::create(Controller::create(), 'TestForm', FieldList::create(), FieldList::create());
         $form->loadDataFrom($blockPage);
         $context = Event::create('action', [
             'form' => $form,
         ]);
+
         $handler->fire($context);
     }
 
-    public function dataProvider()
+    public function dataProvider(): array
     {
         return [
             [true],
-            [false]
+            [false],
         ];
     }
 }

--- a/tests/Handler/GraphQL/FakePageContextProvider.php
+++ b/tests/Handler/GraphQL/FakePageContextProvider.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Tests\Handler\GraphQL;
 
 use SilverStripe\CMS\Model\SiteTree;
@@ -8,6 +7,9 @@ use SilverStripe\Snapshots\Handler\PageContextProvider;
 
 class FakePageContextProvider extends PageContextProvider
 {
+    /**
+     * @var SiteTree|null
+     */
     private $page;
 
     public function setPage(SiteTree $page): self

--- a/tests/Handler/GraphQL/Middleware/HandlerTest.php
+++ b/tests/Handler/GraphQL/Middleware/HandlerTest.php
@@ -2,30 +2,30 @@
 
 namespace SilverStripe\Snapshots\Tests\Handler\GraphQL\Middleware;
 
-use DNADesign\Elemental\Models\BaseElement;
-use DNADesign\Elemental\Models\ElementalArea;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\EventDispatcher\Symfony\Event;
-use SilverStripe\Snapshots\Handler\Elemental\SortElementsHandler;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\GraphQL\Middleware\Handler;
 use SilverStripe\Snapshots\Handler\PageContextProvider;
 use SilverStripe\Snapshots\Tests\Handler\GraphQL\FakePageContextProvider;
-use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
 use SilverStripe\Snapshots\Tests\SnapshotTestAbstract;
 
 class HandlerTest extends SnapshotTestAbstract
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         Injector::inst()->registerService(
-            new FakePageContextProvider(),
+            FakePageContextProvider::create(),
             PageContextProvider::class
         );
     }
 
-    public function testHandlerDoesntFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesntFire(): void
     {
         $handler = Handler::create();
         $this->mockSnapshot()
@@ -39,7 +39,10 @@ class HandlerTest extends SnapshotTestAbstract
         $handler->fire($context);
     }
 
-    public function testHandlerDoesFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesFire(): void
     {
         $handler = Handler::create();
         $blockPage = SiteTree::create();
@@ -50,7 +53,7 @@ class HandlerTest extends SnapshotTestAbstract
         $this->mockSnapshot()
             ->expects($this->once())
             ->method('createSnapshot')
-            ->with($this->callback(function ($arg) use ($blockPage) {
+            ->with($this->callback(static function ($arg) use ($blockPage) {
                 return $arg instanceof SiteTree && $arg->ID == $blockPage->ID;
             }));
 

--- a/tests/Handler/GraphQL/Middleware/RollbackHandlerTest.php
+++ b/tests/Handler/GraphQL/Middleware/RollbackHandlerTest.php
@@ -5,12 +5,16 @@ namespace SilverStripe\Snapshots\Tests\Handler\GraphQL\Middleware;
 use GraphQL\Executor\ExecutionResult;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\EventDispatcher\Symfony\Event;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\GraphQL\Middleware\RollbackHandler;
 use SilverStripe\Snapshots\Tests\SnapshotTestAbstract;
 
 class RollbackHandlerTest extends SnapshotTestAbstract
 {
-    public function testHandlerDoesntFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesntFire(): void
     {
         $handler = RollbackHandler::create();
         $this->mockSnapshot()
@@ -30,7 +34,7 @@ class RollbackHandlerTest extends SnapshotTestAbstract
             'params' => [
                 'id' => 5,
                 'toVersion' => 8,
-            ]
+            ],
         ]);
         $handler->fire($context);
 
@@ -42,13 +46,16 @@ class RollbackHandlerTest extends SnapshotTestAbstract
             'params' => [
                 'id' => $page->ID,
                 'toVersion' => $currentVersion * 100,
-            ]
+            ],
         ]);
 
         $handler->fire($context);
     }
 
-    public function testHandlerDoesFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesFire(): void
     {
         $handler = RollbackHandler::create();
 

--- a/tests/Handler/GraphQL/Mutation/HandlerTest.php
+++ b/tests/Handler/GraphQL/Mutation/HandlerTest.php
@@ -12,7 +12,7 @@ use SilverStripe\Snapshots\Tests\SnapshotTestAbstract;
 
 class HandlerTest extends SnapshotTestAbstract
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         Injector::inst()->registerService(

--- a/tests/Handler/GraphQL/Mutation/HandlerTest.php
+++ b/tests/Handler/GraphQL/Mutation/HandlerTest.php
@@ -21,7 +21,7 @@ class HandlerTest extends SnapshotTestAbstract
         );
     }
 
-    public function testHandlerDoesntFire()
+    public function testHandlerDoesntFire(): void
     {
         $handler = Handler::create();
         $this->mockSnapshot()
@@ -35,7 +35,7 @@ class HandlerTest extends SnapshotTestAbstract
         $handler->fire($context);
     }
 
-    public function testHandlerDoesFire()
+    public function testHandlerDoesFire(): void
     {
         $handler = Handler::create();
         $blockPage = SiteTree::create();
@@ -46,7 +46,7 @@ class HandlerTest extends SnapshotTestAbstract
         $this->mockSnapshot()
             ->expects($this->once())
             ->method('createSnapshot')
-            ->with($this->callback(function ($arg) use ($blockPage) {
+            ->with($this->callback(static function ($arg) use ($blockPage) {
                 return $arg instanceof SiteTree && $arg->ID == $blockPage->ID;
             }));
 

--- a/tests/Handler/GridField/Action/HandlerTest.php
+++ b/tests/Handler/GridField/Action/HandlerTest.php
@@ -7,13 +7,17 @@ use SilverStripe\EventDispatcher\Symfony\Event;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\GridField\Action\Handler;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
 use SilverStripe\Snapshots\Tests\SnapshotTestAbstract;
 
 class HandlerTest extends SnapshotTestAbstract
 {
-    public function testHandlerDoesntFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesntFire(): void
     {
         $handler = Handler::create();
         $this->mockSnapshot()
@@ -34,7 +38,10 @@ class HandlerTest extends SnapshotTestAbstract
         $handler->fire($context);
     }
 
-    public function testHandlerDoesFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesFire(): void
     {
         $handler = Handler::create();
         $block = Block::create();
@@ -43,7 +50,7 @@ class HandlerTest extends SnapshotTestAbstract
         $this->mockSnapshot()
             ->expects($this->once())
             ->method('createSnapshot')
-            ->with($this->callback(function ($arg) use ($block) {
+            ->with($this->callback(static function ($arg) use ($block) {
                 return $arg instanceof Block && $arg->ID == $block->ID;
             }));
 

--- a/tests/Handler/GridField/Action/ReorderHandlerTest.php
+++ b/tests/Handler/GridField/Action/ReorderHandlerTest.php
@@ -14,7 +14,7 @@ use SilverStripe\Snapshots\Tests\SnapshotTestAbstract;
 
 class ReorderHandlerTest extends SnapshotTestAbstract
 {
-    public function testHandlerDoesFire()
+    public function testHandlerDoesFire(): void
     {
         $handler = ReorderHandler::create();
         $block = Block::create();
@@ -25,9 +25,9 @@ class ReorderHandlerTest extends SnapshotTestAbstract
         $mock
             ->expects($this->once())
             ->method('applyOrigin')
-            ->with($this->callback(function ($arg) use ($block) {
+            ->with($this->callback(static function ($arg) use ($block) {
                 return $arg instanceof SnapshotEvent &&
-                    $arg->Title == 'Reordered ' . $block->i18n_plural_name();
+                    $arg->Title === 'Reordered ' . $block->i18n_plural_name();
             }));
 
         $form = Form::create(Controller::create(), 'TestForm', FieldList::create(), FieldList::create())

--- a/tests/Handler/GridField/Alteration/HandlerTest.php
+++ b/tests/Handler/GridField/Alteration/HandlerTest.php
@@ -7,13 +7,17 @@ use SilverStripe\EventDispatcher\Symfony\Event;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\GridField\Alteration\Handler;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
 use SilverStripe\Snapshots\Tests\SnapshotTestAbstract;
 
 class HandlerTest extends SnapshotTestAbstract
 {
-    public function testHandlerDoesntFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesntFire(): void
     {
         $handler = Handler::create();
         $this->mockSnapshot()
@@ -46,7 +50,10 @@ class HandlerTest extends SnapshotTestAbstract
         $handler->fire($context);
     }
 
-    public function testHandlerDoesFire()
+    /**
+     * @throws ValidationException
+     */
+    public function testHandlerDoesFire(): void
     {
         $handler = Handler::create();
         $block = Block::create();
@@ -55,7 +62,7 @@ class HandlerTest extends SnapshotTestAbstract
         $this->mockSnapshot()
             ->expects($this->once())
             ->method('createSnapshot')
-            ->with($this->callback(function ($arg) use ($block) {
+            ->with($this->callback(static function ($arg) use ($block) {
                 return $arg instanceof Block && $arg->ID == $block->ID;
             }));
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -490,9 +490,11 @@ class IntegrationTest extends SnapshotTestAbstract
      */
     public function testRevertChanges(): void
     {
-        /** @var DataObject|SnapshotPublishable $a1 */
-        /** @var DataObject|SnapshotPublishable|Versioned $gallery1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $state = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
+        /** @var Gallery|SnapshotPublishable|Versioned $gallery1 */
+        $gallery1 = $state['gallery1'];
 
         $this->editingPage($a1);
         $this->formPublishObject($a1);
@@ -532,11 +534,13 @@ class IntegrationTest extends SnapshotTestAbstract
      */
     public function testIntermediaryObjects(): void
     {
-        /** @var DataObject|SnapshotPublishable $a1 */
-        /** @var DataObject|SnapshotPublishable $a2 */
-        /** @var DataObject|SnapshotPublishable $a1Block1 */
-        /** @var DataObject|SnapshotPublishable $gallery1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $state = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
+        /** @var Block|SnapshotPublishable $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
+        /** @var Gallery|SnapshotPublishable $gallery1 */
+        $gallery1 = $state['gallery1'];
 
         $this->publish($a1);
         $this->editingPage($a1);
@@ -615,12 +619,17 @@ class IntegrationTest extends SnapshotTestAbstract
      */
     public function testChangeOwnershipStructure(): void
     {
-        /** @var DataObject|SnapshotPublishable $a1 */
-        /** @var DataObject|SnapshotPublishable $a2 */
+        $state = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
+        /** @var BlockPage|SnapshotPublishable $a2 */
+        $a2 = $state['a2'];
         /** @var Block|SnapshotPublishable $a1Block1 */
-        /** @var DataObject|SnapshotPublishable $gallery1 */
-        /** @var DataObject|SnapshotPublishable $gallery2 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1Block1 = $state['a1Block1'];
+        /** @var Gallery|SnapshotPublishable $gallery1 */
+        $gallery1 = $state['gallery1'];
+        /** @var Gallery|SnapshotPublishable $gallery2 */
+        $gallery2 = $state['gallery2'];
 
         $this->editingPage($a1);
         $this->formPublishObject($a1);
@@ -845,11 +854,15 @@ class IntegrationTest extends SnapshotTestAbstract
      */
     public function testPartialActivityMigration(): void
     {
-        /** @var DataObject|SnapshotPublishable $a1 */
-        /** @var DataObject|SnapshotPublishable $a2 */
+        $state = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
+        /** @var BlockPage|SnapshotPublishable $a2 */
+        $a2 = $state['a2'];
         /** @var Block|SnapshotPublishable $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
         /** @var Block|SnapshotPublishable $a1Block2 */
-        [$a1, $a2, $a1Block1, $a1Block2] = $this->buildState();
+        $a1Block2 = $state['a1Block2'];
 
         // Test that we can transplant a node and relevant activity will be migrated
         // but unrelated activity will be preserved.
@@ -922,13 +935,17 @@ class IntegrationTest extends SnapshotTestAbstract
      */
     public function testDeletions(): void
     {
-        /** @var DataObject|SnapshotPublishable $a1 */
-        /** @var DataObject|SnapshotPublishable $a2 */
-        /** @var DataObject|SnapshotPublishable $a1Block1 */
-        /** @var DataObject|SnapshotPublishable $a1Block2 */
-        /** @var DataObject|SnapshotPublishable $a2Block1 */
-        /** @var DataObject|SnapshotPublishable $gallery2 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $state = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
+        /** @var BlockPage|SnapshotPublishable $a2 */
+        $a2 = $state['a2'];
+        /** @var Block|SnapshotPublishable $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
+        /** @var Block|SnapshotPublishable $a2Block1 */
+        $a2Block1 = $state['a2Block1'];
+        /** @var Gallery|SnapshotPublishable $gallery2 */
+        $gallery2 = $state['gallery2'];
 
         $this->editingPage($a1);
         $this->formPublishObject($a1);
@@ -1000,15 +1017,21 @@ class IntegrationTest extends SnapshotTestAbstract
      */
     public function testGetAtSnapshot(): void
     {
-        $stamp0 = $this->sleep(1);
+         $this->sleep(1);
 
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
         /** @var BlockPage|SnapshotPublishable $a2 */
+        $a2 = $state['a2'];
         /** @var Block|SnapshotPublishable $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
         /** @var Block|SnapshotPublishable $a1Block2 */
+        $a1Block2 = $state['a1Block2'];
         /** @var Block|SnapshotPublishable $a2Block1 */
-        /** @var DataObject|SnapshotPublishable $gallery2 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a2Block1 = $state['a2Block1'];
+        /** @var Gallery|SnapshotPublishable $gallery1 */
+        $gallery1 = $state['gallery1'];
 
         $this->editingPage($a1);
         $this->formPublishObject($a1);
@@ -1050,12 +1073,12 @@ class IntegrationTest extends SnapshotTestAbstract
 
         $this->formSaveObject($a2Block2);
 
-        $stamp6 = $this->sleep(1);
+        $this->sleep(1);
 
         $a2Block1->Title = 'A2 Block 1 changed';
         $this->formSaveObject($a2Block1);
 
-        $stamp7 = $this->sleep(1);
+        $this->sleep(1);
         $a2->Title = 'The new A2';
         $this->formSaveObject($a2);
 
@@ -1534,6 +1557,7 @@ class IntegrationTest extends SnapshotTestAbstract
     /**
      * @param DataObject $object
      * @throws ValidationException
+     * @throws Exception
      */
     private function formSaveObject(DataObject $object): void
     {
@@ -1561,6 +1585,7 @@ class IntegrationTest extends SnapshotTestAbstract
 
     /**
      * @param DataObject|Versioned $object
+     * @throws Exception
      */
     private function formUnpublishObject(DataObject $object): void
     {
@@ -1572,6 +1597,7 @@ class IntegrationTest extends SnapshotTestAbstract
 
     /**
      * @param DataObject|Versioned $object
+     * @throws Exception
      */
     private function formDeleteObject(DataObject $object): void
     {
@@ -1589,6 +1615,7 @@ class IntegrationTest extends SnapshotTestAbstract
      * @param string $component
      * @param DataObject[] $items
      * @param string $type
+     * @throws Exception
      */
     private function formSaveRelations(
         DataObject $object,

--- a/tests/PageContextProviderTest.php
+++ b/tests/PageContextProviderTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Tests;
 
 use SilverStripe\CMS\Model\SiteTree;
@@ -9,13 +8,19 @@ use SilverStripe\Snapshots\Handler\PageContextProvider;
 
 class PageContextProviderTest extends SapphireTest
 {
+    /**
+     * @var SiteTree|null
+     */
     private $page;
 
+    /**
+     * @var array
+     */
     protected static $extra_dataobjects = [
         SiteTree::class,
     ];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $page = SiteTree::create();
@@ -26,13 +31,14 @@ class PageContextProviderTest extends SapphireTest
     /**
      * @dataProvider dataProvider
      */
-    public function testPageFromURL(string $testURL, bool $shouldSucceed)
+    public function testPageFromURL(string $testURL, bool $shouldSucceed): void
     {
-        $provider = new PageContextProvider();
+        $provider = PageContextProvider::create();
         // Strip out the placeholder and use the real ID.
         $url = str_replace('[ID]', $this->page->ID, $testURL);
 
         $result = $provider->getCurrentPageFromRequestUrl($url);
+
         if ($shouldSucceed) {
             $this->assertInstanceOf(SiteTree::class, $result);
             $this->assertEquals($this->page->ID, $result->ID);
@@ -41,7 +47,7 @@ class PageContextProviderTest extends SapphireTest
         }
     }
 
-    public function dataProvider()
+    public function dataProvider(): array
     {
         // This is called before the database is ready, so [ID] is used as a placeholder
         return [

--- a/tests/RelationDifferTest.php
+++ b/tests/RelationDifferTest.php
@@ -3,24 +3,28 @@
 namespace SilverStripe\Snapshots\Tests;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\RelationDiffer;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
 
 class RelationDifferTest extends SapphireTest
 {
+    /**
+     * @var array
+     */
     protected static $extra_dataobjects = [
         Block::class,
     ];
 
-    public function testDiffRemoved()
+    public function testDiffRemoved(): void
     {
-        $differ = new RelationDiffer(
+        $differ = RelationDiffer::create(
             Block::class,
             'has_many',
             [
                 '1' => 5,
                 '2' => 12,
-                '5' => 8
+                '5' => 8,
             ],
             []
         );
@@ -30,16 +34,16 @@ class RelationDifferTest extends SapphireTest
         $this->assertEquals(['1','2','5'], $differ->getRemoved());
     }
 
-    public function testDiffAdded()
+    public function testDiffAdded(): void
     {
-        $differ = new RelationDiffer(
+        $differ = RelationDiffer::create(
             Block::class,
             'has_many',
             [],
             [
                 '1' => 5,
                 '2' => 12,
-                '5' => 8
+                '5' => 8,
             ]
         );
         $this->assertTrue($differ->hasChanges());
@@ -48,9 +52,9 @@ class RelationDifferTest extends SapphireTest
         $this->assertEquals(['1','2','5'], $differ->getAdded());
     }
 
-    public function testDiffChanged()
+    public function testDiffChanged(): void
     {
-        $differ = new RelationDiffer(
+        $differ = RelationDiffer::create(
             Block::class,
             'has_many',
             [
@@ -76,9 +80,9 @@ class RelationDifferTest extends SapphireTest
         $this->assertEquals(['1','9','16'], $changed);
     }
 
-    public function testDiffMixed()
+    public function testDiffMixed(): void
     {
-        $differ = new RelationDiffer(
+        $differ = RelationDiffer::create(
             Block::class,
             'has_many',
             [
@@ -115,9 +119,9 @@ class RelationDifferTest extends SapphireTest
         $this->assertFalse($differ->isChanged(16));
     }
 
-    public function testNoChanges()
+    public function testNoChanges(): void
     {
-        $differ = new RelationDiffer(
+        $differ = RelationDiffer::create(
             Block::class,
             'has_many',
             [
@@ -146,7 +150,10 @@ class RelationDifferTest extends SapphireTest
         $this->assertEmpty($differ->getRemoved());
     }
 
-    public function testGetRecords()
+    /**
+     * @throws ValidationException
+     */
+    public function testGetRecords(): void
     {
         $block1 = Block::create();
         $block1->write();
@@ -155,7 +162,7 @@ class RelationDifferTest extends SapphireTest
         $block3 = Block::create();
         $block3->write();
 
-        $differ = new RelationDiffer(
+        $differ = RelationDiffer::create(
             Block::class,
             'has_many',
             [
@@ -166,20 +173,22 @@ class RelationDifferTest extends SapphireTest
                 $block2->ID => $block2->Version,
             ]
         );
+
         $this->assertTrue($differ->hasChanges());
         $this->assertCount(3, $differ->getRecords());
         $expected = [$block1->ID, $block2->ID, $block3->ID];
         sort($expected);
-        $actual = array_map(function ($record) {
+
+        $actual = array_map(static function ($record) {
             return $record->ID;
         }, $differ->getRecords());
         sort($actual);
         $this->assertEquals($expected, $actual);
     }
 
-    public function testException()
+    public function testException(): void
     {
         $this->expectException('InvalidArgumentException');
-        new RelationDiffer(static::class, 'test');
+        RelationDiffer::create(static::class, 'test');
     }
 }

--- a/tests/RelationDifferTest.php
+++ b/tests/RelationDifferTest.php
@@ -6,6 +6,7 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\RelationDiffer;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
+use SilverStripe\Versioned\Versioned;
 
 class RelationDifferTest extends SapphireTest
 {
@@ -155,10 +156,13 @@ class RelationDifferTest extends SapphireTest
      */
     public function testGetRecords(): void
     {
+        /** @var Block|Versioned $block1 */
         $block1 = Block::create();
         $block1->write();
+        /** @var Block|Versioned $block2 */
         $block2 = Block::create();
         $block2->write();
+        /** @var Block|Versioned $block3 */
         $block3 = Block::create();
         $block3->write();
 

--- a/tests/SnapshotItemTest.php
+++ b/tests/SnapshotItemTest.php
@@ -2,20 +2,27 @@
 
 namespace SilverStripe\Snapshots\Tests;
 
+use Exception;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\SnapshotHasher;
 use SilverStripe\Snapshots\SnapshotItem;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
+use SilverStripe\Versioned\Versioned;
 
 class SnapshotItemTest extends SnapshotTestAbstract
 {
-    public function testGetItem()
+    /**
+     * @throws ValidationException
+     */
+    public function testGetItem(): void
     {
+        /** @var Block|Versioned $block */
         $block = Block::create();
         $block->write();
         $item = SnapshotItem::create([
             'ObjectClass' => Block::class,
             'ObjectID' => $block->ID,
-            'Version' => $block->Version * 100
+            'Version' => $block->Version * 100,
         ]);
 
         $this->assertNull($item->getItem());
@@ -27,8 +34,13 @@ class SnapshotItemTest extends SnapshotTestAbstract
         $this->assertEquals($block->Version, $item->getItem()->Version);
     }
 
-    public function testHydration()
+    /**
+     * @throws ValidationException
+     * @throws Exception
+     */
+    public function testHydration(): void
     {
+        /** @var Block|Versioned $block */
         $block = Block::create();
         $block->write();
 

--- a/tests/SnapshotPublishableTest.php
+++ b/tests/SnapshotPublishableTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Snapshots\Tests;
 
+use Exception;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
@@ -14,12 +15,18 @@ use SilverStripe\Versioned\Versioned;
 
 class SnapshotPublishableTest extends SnapshotTestAbstract
 {
+    /**
+     * @throws ValidationException
+     */
     public function testGetAtSnapshot(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage $a1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1 = $state['a1'];
+
         $firstSnapshot = Snapshot::get()->sort('Created ASC')->first();
         $result = SnapshotPublishable::get_at_snapshot(BlockPage::class, $a1->ID, $firstSnapshot->Created);
+
         $param = $result->getSourceQueryParam('Versioned.date');
         $this->assertNotNull($param);
         $this->assertEquals($firstSnapshot->Created, $param);
@@ -30,8 +37,10 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
      */
     public function testGetAtLastSnapshot(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage $a1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1 = $state['a1'];
+
         $a1->Title = 'changed';
         $a1->write();
 
@@ -40,10 +49,14 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertEquals('A1 Block Page', $result->Title);
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testGetLastSnapshotItem(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|Versioned $a1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1 = $state['a1'];
         $a1->Title = 'changed';
         $this->snapshot($a1);
 
@@ -53,6 +66,9 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertEquals($a1->Version, $result->Version);
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testGetSnapshots(): void
     {
         $state = $this->buildState();
@@ -60,11 +76,26 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertOrigins($snapshots, $state);
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testGetRelevantSnapshots(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
         /** @var BlockPage|SnapshotPublishable $a2 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a2 = $state['a2'];
+        /** @var Block $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
+        /** @var Block $a1Block2 */
+        $a1Block2 = $state['a1Block2'];
+        /** @var Block $a2Block1 */
+        $a2Block1 = $state['a2Block1'];
+        /** @var Gallery $gallery1 */
+        $gallery1 = $state['gallery1'];
+        /** @var Gallery $gallery2 */
+        $gallery2 = $state['gallery2'];
         $a1->Title = 'changed';
         $this->snapshot($a1);
 
@@ -96,15 +127,24 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         );
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testGetSnapshotsSinceVersion(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
         /** @var Block $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
         /** @var Block $a1Block2 */
+        $a1Block2 = $state['a1Block2'];
         /** @var Block $a2Block1 */
+        $a2Block1 = $state['a2Block1'];
         /** @var Gallery $gallery1 */
+        $gallery1 = $state['gallery1'];
         /** @var Gallery $gallery2 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $gallery2 = $state['gallery2'];
         $this->publish($a1);
         $fromVersion = Versioned::get_versionnumber_by_stage(BlockPage::class, Versioned::LIVE, $a1->ID);
 
@@ -145,13 +185,20 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         );
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testHasOwnedModifications(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
         /** @var BlockPage|SnapshotPublishable $a2 */
+        $a2 = $state['a2'];
         /** @var Block $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
         /** @var Block $a1Block2 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1Block2 = $state['a1Block2'];
         $this->publish($a1);
         $this->publish($a2);
 
@@ -168,14 +215,22 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertFalse($a2->hasOwnedModifications());
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testPublishableItems(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
         /** @var BlockPage|SnapshotPublishable $a2 */
+        $a2 = $state['a2'];
         /** @var Block $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
         /** @var Block $a2Block1 */
+        $a2Block1 = $state['a2Block1'];
         /** @var Gallery $gallery1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $gallery1 = $state['gallery1'];
         $this->publish($a1);
         $this->publish($a2);
 
@@ -217,12 +272,18 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertEquals($classes, $a2->getPublishableObjects()->column('ClassName'));
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testGetRelationTracking(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
         /** @var Block|Versioned $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
         /** @var Block|Versioned $a1Block2 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1Block2 = $state['a1Block2'];
         $this->assertEmpty($a1->getRelationTracking());
         Config::modify()->set(BlockPage::class, 'snapshot_relation_tracking', ['Blocks', 'Fail']);
         $result = $a1->getRelationTracking();
@@ -233,10 +294,14 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertEquals($a1Block2->Version, $result['Blocks'][$a1Block2->ID]);
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testPreviousSnapshotItem(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1 = $state['a1'];
         $a1->Title = 'changed';
         $this->snapshot($a1);
         $version = Versioned::get_versionnumber_by_stage(BlockPage::class, Versioned::DRAFT, $a1->ID);
@@ -250,8 +315,9 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
      */
     public function testPreviousSnapshot(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1 = $state['a1'];
         $a1->Title = 'changed';
         $this->snapshot($a1);
 
@@ -275,10 +341,11 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
     /**
      * @throws ValidationException
      */
-    public function testIsModifiedSinceLastSnapshot()
+    public function testIsModifiedSinceLastSnapshot(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1 = $state['a1'];
         $this->assertFalse($a1->isModifiedSinceLastSnapshot());
         $a1->Title = 'changed';
         $a1->write();
@@ -289,25 +356,35 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertTrue($obj->isModifiedSinceLastSnapshot());
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testGetIntermediaryObjects(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
         /** @var Block|SnapshotPublishable $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
         /** @var Gallery|SnapshotPublishable $gallery1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $gallery1 = $state['gallery1'];
         $objs = $gallery1->getIntermediaryObjects();
         $this->assertHashCompareList([$a1Block1, $a1], $objs);
     }
 
     /**
      * @throws ValidationException
+     * @throws Exception
      */
     public function testGetRelationDiffs(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = $state['a1'];
         /** @var Block|SnapshotPublishable $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
         /** @var Block|SnapshotPublishable $a1Block2 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1Block2 = $state['a1Block2'];
         Config::modify()->set(BlockPage::class, 'snapshot_relation_tracking', ['Blocks']);
 
         $this->assertCount(1, $a1->getRelationDiffs());
@@ -357,10 +434,14 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertEquals([$a1Block1->ID], $diff->getChanged());
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testGetPreviousVersion(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage|SnapshotPublishable $a1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1 = $state['a1'];
         $originalTitle = $a1->Title;
         $a1->Title = 'changed';
         $this->snapshot($a1);

--- a/tests/SnapshotPublishableTest.php
+++ b/tests/SnapshotPublishableTest.php
@@ -4,17 +4,20 @@ namespace SilverStripe\Snapshots\Tests;
 
 use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotPublishable;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
+use SilverStripe\Snapshots\Tests\SnapshotTest\Gallery;
 use SilverStripe\Versioned\Versioned;
 
 class SnapshotPublishableTest extends SnapshotTestAbstract
 {
-    public function testGetAtSnapshot()
+    public function testGetAtSnapshot(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage $a1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $firstSnapshot = Snapshot::get()->sort('Created ASC')->first();
         $result = SnapshotPublishable::get_at_snapshot(BlockPage::class, $a1->ID, $firstSnapshot->Created);
         $param = $result->getSourceQueryParam('Versioned.date');
@@ -22,9 +25,13 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertEquals($firstSnapshot->Created, $param);
     }
 
-    public function testGetAtLastSnapshot()
+    /**
+     * @throws ValidationException
+     */
+    public function testGetAtLastSnapshot(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage $a1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $a1->Title = 'changed';
         $a1->write();
 
@@ -33,27 +40,31 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertEquals('A1 Block Page', $result->Title);
     }
 
-    public function testGetLastSnapshotItem()
+    public function testGetLastSnapshotItem(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|Versioned $a1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $a1->Title = 'changed';
         $this->snapshot($a1);
 
+        /** @var DataObject|Versioned $result */
         $result = SnapshotPublishable::get_last_snapshot_item(BlockPage::class, $a1->ID);
         $this->assertNotNull($result);
         $this->assertEquals($a1->Version, $result->Version);
     }
 
-    public function testGetSnapshots()
+    public function testGetSnapshots(): void
     {
-        $arr = $this->buildState();
+        $state = $this->buildState();
         $snapshots = SnapshotPublishable::getSnapshots();
-        $this->assertOrigins($snapshots, $arr);
+        $this->assertOrigins($snapshots, $state);
     }
 
-    public function testGetRelevantSnapshots()
+    public function testGetRelevantSnapshots(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        /** @var BlockPage|SnapshotPublishable $a2 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $a1->Title = 'changed';
         $this->snapshot($a1);
 
@@ -80,14 +91,20 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
             [
                 $a2,
                 $a2Block1,
-                $gallery2
+                $gallery2,
             ]
         );
     }
 
-    public function testGetSnapshotsSinceVersion()
+    public function testGetSnapshotsSinceVersion(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        /** @var Block $a1Block1 */
+        /** @var Block $a1Block2 */
+        /** @var Block $a2Block1 */
+        /** @var Gallery $gallery1 */
+        /** @var Gallery $gallery2 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $this->publish($a1);
         $fromVersion = Versioned::get_versionnumber_by_stage(BlockPage::class, Versioned::LIVE, $a1->ID);
 
@@ -128,9 +145,13 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         );
     }
 
-    public function testHasOwnedModifications()
+    public function testHasOwnedModifications(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        /** @var BlockPage|SnapshotPublishable $a2 */
+        /** @var Block $a1Block1 */
+        /** @var Block $a1Block2 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $this->publish($a1);
         $this->publish($a2);
 
@@ -147,9 +168,14 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertFalse($a2->hasOwnedModifications());
     }
 
-    public function testPublishableItems()
+    public function testPublishableItems(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        /** @var BlockPage|SnapshotPublishable $a2 */
+        /** @var Block $a1Block1 */
+        /** @var Block $a2Block1 */
+        /** @var Gallery $gallery1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $this->publish($a1);
         $this->publish($a2);
 
@@ -191,21 +217,26 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertEquals($classes, $a2->getPublishableObjects()->column('ClassName'));
     }
 
-    public function testGetRelationTracking()
+    public function testGetRelationTracking(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        /** @var Block|Versioned $a1Block1 */
+        /** @var Block|Versioned $a1Block2 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $this->assertEmpty($a1->getRelationTracking());
         Config::modify()->set(BlockPage::class, 'snapshot_relation_tracking', ['Blocks', 'Fail']);
         $result = $a1->getRelationTracking();
+
         $this->assertArrayHasKey('Blocks', $result);
         $this->assertArrayNotHasKey('Fail', $result);
         $this->assertEquals($a1Block1->Version, $result['Blocks'][$a1Block1->ID]);
         $this->assertEquals($a1Block2->Version, $result['Blocks'][$a1Block2->ID]);
     }
 
-    public function testPreviousSnapshotItem()
+    public function testPreviousSnapshotItem(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $a1->Title = 'changed';
         $this->snapshot($a1);
         $version = Versioned::get_versionnumber_by_stage(BlockPage::class, Versioned::DRAFT, $a1->ID);
@@ -214,9 +245,13 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertHashCompare($a1, $item->getItem());
     }
 
-    public function testPreviousSnapshot()
+    /**
+     * @throws ValidationException
+     */
+    public function testPreviousSnapshot(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $a1->Title = 'changed';
         $this->snapshot($a1);
 
@@ -225,8 +260,10 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
 
         $result = $a1->atPreviousSnapshot(function ($date) use ($a1) {
             $this->assertNotNull($date);
+
             return DataObject::get_by_id(BlockPage::class, $a1->ID);
         });
+
         $this->assertNotNull($result);
         $this->assertEquals('changed', $result->Title);
 
@@ -235,27 +272,42 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertEquals('changed', $result->Title);
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testIsModifiedSinceLastSnapshot()
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $this->assertFalse($a1->isModifiedSinceLastSnapshot());
         $a1->Title = 'changed';
         $a1->write();
+
+        /** @var BlockPage|SnapshotPublishable $obj */
         $obj = DataObject::get_by_id(BlockPage::class, $a1->ID);
 
         $this->assertTrue($obj->isModifiedSinceLastSnapshot());
     }
 
-    public function testGetIntermediaryObjects()
+    public function testGetIntermediaryObjects(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        /** @var Block|SnapshotPublishable $a1Block1 */
+        /** @var Gallery|SnapshotPublishable $gallery1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $objs = $gallery1->getIntermediaryObjects();
         $this->assertHashCompareList([$a1Block1, $a1], $objs);
     }
 
-    public function testGetRelationDiffs()
+    /**
+     * @throws ValidationException
+     */
+    public function testGetRelationDiffs(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        /** @var Block|SnapshotPublishable $a1Block1 */
+        /** @var Block|SnapshotPublishable $a1Block2 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         Config::modify()->set(BlockPage::class, 'snapshot_relation_tracking', ['Blocks']);
 
         $this->assertCount(1, $a1->getRelationDiffs());
@@ -305,9 +357,10 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertEquals([$a1Block1->ID], $diff->getChanged());
     }
 
-    public function testGetPreviousVersion()
+    public function testGetPreviousVersion(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $originalTitle = $a1->Title;
         $a1->Title = 'changed';
         $this->snapshot($a1);

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -1,10 +1,10 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Tests;
 
+use Exception;
 use SilverStripe\Core\Config\Config;
-use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotEvent;
 use SilverStripe\Snapshots\SnapshotItem;
@@ -12,27 +12,35 @@ use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Gallery;
 use SilverStripe\Snapshots\Tests\SnapshotTest\GalleryImage;
+use SilverStripe\Versioned\Versioned;
 
 class SnapshotTest extends SnapshotTestAbstract
 {
+    /**
+     * @var bool
+     */
     protected $usesTransactions = false;
 
-    public function testGetOriginItem()
+    /**
+     * @throws ValidationException
+     */
+    public function testGetOriginItem(): void
     {
         $snapshot = Snapshot::create();
         $snapshot->write();
-        $item = SnapshotItem::create([
-            'ObjectClass' => Block::class,
-            'ObjectID' => 5,
-            'SnapshotID' => $snapshot->ID,
-        ]);
+
+        $item = SnapshotItem::create();
+        $item->ObjectClass = Block::class;
+        $item->ObjectID = 5;
+        $item->SnapshotID = $snapshot->ID;
         $item->write();
-        $item = SnapshotItem::create([
-            'ObjectClass' => Block::class,
-            'ObjectID' => 7,
-            'SnapshotID' => $snapshot->ID,
-        ]);
+
+        $item = SnapshotItem::create();
+        $item->ObjectClass = Block::class;
+        $item->ObjectID = 7;
+        $item->SnapshotID = $snapshot->ID;
         $item->write();
+
         $snapshot->OriginClass = $item->ObjectClass;
         $snapshot->OriginID = $item->ObjectID;
         $snapshot->write();
@@ -44,19 +52,29 @@ class SnapshotTest extends SnapshotTestAbstract
         $this->assertEquals($item->ObjectID, $origin->ObjectID);
     }
 
-    public function testAddObjectLimit()
+    /**
+     * @throws ValidationException
+     * @throws Exception
+     */
+    public function testAddObjectLimit(): void
     {
         Config::modify()->set(Snapshot::class, 'item_limit', 5);
         $snapshot = Snapshot::create();
-        for ($i = 0; $i < 10; $i++) {
+
+        for ($i = 0; $i < 10; $i += 1) {
             $b = Block::create();
             $b->write();
             $snapshot->addObject($b);
         }
+
         $this->assertCount(5, $snapshot->Items());
     }
 
-    public function testAddObjectDuplication()
+    /**
+     * @throws ValidationException
+     * @throws Exception
+     */
+    public function testAddObjectDuplication(): void
     {
         $snapshot = Snapshot::create();
         $block1 = Block::create();
@@ -81,7 +99,11 @@ class SnapshotTest extends SnapshotTestAbstract
         $this->assertEquals($expected, $ids);
     }
 
-    public function testAddObjectAsSnapshotItem()
+    /**
+     * @throws ValidationException
+     * @throws Exception
+     */
+    public function testAddObjectAsSnapshotItem(): void
     {
         $snapshot = Snapshot::create();
         $block1 = Block::create();
@@ -109,32 +131,41 @@ class SnapshotTest extends SnapshotTestAbstract
         $this->assertEquals($expected, $ids);
     }
 
-    public function testGetOriginVersion()
+    /**
+     * @throws ValidationException
+     */
+    public function testGetOriginVersion(): void
     {
         $snapshot = Snapshot::create();
         $snapshot->write();
+
+        /** @var Block|Versioned $block1 */
         $block1 = Block::create();
         $block1->write();
-        $item = SnapshotItem::create([
-            'ObjectClass' => $block1->baseClass(),
-            'ObjectID' => $block1->ID,
-            'SnapshotID' => $snapshot->ID,
-            'Version' => $block1->Version,
-        ]);
+
+        $item = SnapshotItem::create();
+        $item->ObjectClass = $block1->baseClass();
+        $item->ObjectID = $block1->ID;
+        $item->SnapshotID = $snapshot->ID;
+        $item->Version = $block1->Version;
         $item->write();
-        $block2 = Block::create(['Title' => 'Original title']);
+
+        /** @var Block|Versioned $block2 */
+        $block2 = Block::create();
+        $block2->Title = 'Original title';
         $block2->write();
+
         $expectedVersion = $block2->Version;
         $block2->Title = 'changed title';
         $block2->write();
 
-        $item = SnapshotItem::create([
-            'ObjectClass' => $block2->baseClass(),
-            'ObjectID' => $block2->ID,
-            'SnapshotID' => $snapshot->ID,
-            'Version' => $expectedVersion,
-        ]);
+        $item = SnapshotItem::create();
+        $item->ObjectClass = $block2->baseClass();
+        $item->ObjectID = $block2->ID;
+        $item->SnapshotID = $snapshot->ID;
+        $item->Version = $expectedVersion;
         $item->write();
+
         $snapshot->OriginClass = $item->ObjectClass;
         $snapshot->OriginID = $item->ObjectID;
         $snapshot->write();
@@ -145,9 +176,16 @@ class SnapshotTest extends SnapshotTestAbstract
         $this->assertEquals('Original title', $v->Title);
     }
 
-    public function testCreateSnapshotNoRelations()
+    /**
+     * @throws ValidationException
+     */
+    public function testCreateSnapshotNoRelations(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage $a1 */
+        /** @var Block $a1Block1 */
+        /** @var Block $a2Block1 */
+        /** @var Gallery $gallery1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $gallery1->Title = 'changed';
         $snapshot = $this->snapshot($gallery1);
         $this->assertCount(3, $snapshot->Items());
@@ -196,9 +234,15 @@ class SnapshotTest extends SnapshotTestAbstract
         );
     }
 
-    public function testCreateSnapshotWithImplicitModifications()
+    /**
+     * @throws ValidationException
+     */
+    public function testCreateSnapshotWithImplicitModifications(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage $a1 */
+        /** @var Block $a1Block1 */
+        /** @var Gallery $gallery1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $image = GalleryImage::create();
         $image->write();
 
@@ -265,7 +309,10 @@ class SnapshotTest extends SnapshotTestAbstract
         $this->assertRegExp('/Added ' . $name . '/', $origin->Title);
     }
 
-    public function testCreateSnapshotEvent()
+    /**
+     * @throws ValidationException
+     */
+    public function testCreateSnapshotEvent(): void
     {
         $snapshot = Snapshot::singleton()->createSnapshotEvent('test event');
         $snapshot->write();
@@ -290,14 +337,21 @@ class SnapshotTest extends SnapshotTestAbstract
             [
                 $event,
                 $block1,
-                $block2
+                $block2,
             ]
         );
     }
 
-    public function testAddOwnershipChain()
+    /**
+     * @throws ValidationException
+     * @throws Exception
+     */
+    public function testAddOwnershipChain(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage $a1 */
+        /** @var Block $a1Block1 */
+        /** @var Gallery $gallery1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         $snapshot = Snapshot::create();
         $this->assertEmpty($snapshot->Items());
         $snapshot->addOwnershipChain($gallery1);
@@ -313,22 +367,28 @@ class SnapshotTest extends SnapshotTestAbstract
         );
     }
 
-    public function testApplyOrigin()
+    /**
+     * @throws ValidationException
+     * @throws Exception
+     */
+    public function testApplyOrigin(): void
     {
         $snapshot = Snapshot::create();
-        $this->assertFalse($snapshot->getOriginItem());
+        $this->assertNull($snapshot->getOriginItem());
         $block = Block::create();
         $block->write();
         $snapshot->applyOrigin($block);
-        $this->assertNotFalse($snapshot->getOriginItem());
+        $this->assertNotNull($snapshot->getOriginItem());
         $item = $snapshot->getOriginItem()->getItem();
         $this->assertNotNull($item);
         $this->assertHashCompare($item, $block);
     }
 
-    public function testIsLiveSnapshot()
+    public function testIsLiveSnapshot(): void
     {
-        list($a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2) = $this->buildState();
+        /** @var BlockPage $a1 */
+        /** @var Block $a1Block1 */
+        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
         Snapshot::get()->removeAll();
         SnapshotItem::get()->removeAll();
         $this->assertCount(0, Snapshot::get());
@@ -340,13 +400,16 @@ class SnapshotTest extends SnapshotTestAbstract
 
         $this->assertCount(4, Snapshot::get());
         $liveSnapshots = [];
-        foreach (Snapshot::get() as $s) {
-            if ($s->getIsLiveSnapshot()) {
-                $liveSnapshots[] = $s;
-            }
-        }
-        $this->assertCount(1, $liveSnapshots);
 
+        foreach (Snapshot::get() as $s) {
+            if (!$s->getIsLiveSnapshot()) {
+                continue;
+            }
+
+            $liveSnapshots[] = $s;
+        }
+
+        $this->assertCount(1, $liveSnapshots);
         $this->assertEquals(Snapshot::get()->max('ID'), $liveSnapshots[0]->ID);
     }
 }

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -181,11 +181,15 @@ class SnapshotTest extends SnapshotTestAbstract
      */
     public function testCreateSnapshotNoRelations(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage $a1 */
+        $a1 = $state['a1'];
         /** @var Block $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
         /** @var Block $a2Block1 */
+        $a2Block1 = $state['a2Block1'];
         /** @var Gallery $gallery1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $gallery1 = $state['gallery1'];
         $gallery1->Title = 'changed';
         $snapshot = $this->snapshot($gallery1);
         $this->assertCount(3, $snapshot->Items());
@@ -239,10 +243,13 @@ class SnapshotTest extends SnapshotTestAbstract
      */
     public function testCreateSnapshotWithImplicitModifications(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage $a1 */
+        $a1 = $state['a1'];
         /** @var Block $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
         /** @var Gallery $gallery1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $gallery1 = $state['gallery1'];
         $image = GalleryImage::create();
         $image->write();
 
@@ -348,10 +355,13 @@ class SnapshotTest extends SnapshotTestAbstract
      */
     public function testAddOwnershipChain(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage $a1 */
+        $a1 = $state['a1'];
         /** @var Block $a1Block1 */
+        $a1Block1 = $state['a1Block1'];
         /** @var Gallery $gallery1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $gallery1 = $state['gallery1'];
         $snapshot = Snapshot::create();
         $this->assertEmpty($snapshot->Items());
         $snapshot->addOwnershipChain($gallery1);
@@ -384,11 +394,16 @@ class SnapshotTest extends SnapshotTestAbstract
         $this->assertHashCompare($item, $block);
     }
 
+    /**
+     * @throws ValidationException
+     */
     public function testIsLiveSnapshot(): void
     {
+        $state = $this->buildState();
         /** @var BlockPage $a1 */
+        $a1 = $state['a1'];
         /** @var Block $a1Block1 */
-        [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2] = $this->buildState();
+        $a1Block1 = $state['a1Block1'];
         Snapshot::get()->removeAll();
         SnapshotItem::get()->removeAll();
         $this->assertCount(0, Snapshot::get());

--- a/tests/SnapshotTest/BaseJoin.php
+++ b/tests/SnapshotTest/BaseJoin.php
@@ -11,6 +11,9 @@ use SilverStripe\Versioned\Versioned;
  */
 class BaseJoin extends DataObject implements TestOnly
 {
+    /**
+     * @var array
+     */
     private static $extensions = [
         Versioned::class,
     ];

--- a/tests/SnapshotTest/Block.php
+++ b/tests/SnapshotTest/Block.php
@@ -1,31 +1,56 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Tests\SnapshotTest;
 
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\HasManyList;
 use SilverStripe\Versioned\Versioned;
 
+/**
+ * @property string $Title
+ * @property int $ParentID
+ * @method HasManyList|Gallery[] Galleries()
+ */
 class Block extends DataObject implements TestOnly
 {
+    /**
+     * @var array
+     */
     private static $db = [
         'Title' => 'Varchar',
     ];
 
+    /**
+     * @var array
+     */
     private static $has_one = [
         'Parent' => BlockPage::class,
     ];
 
+    /**
+     * @var array
+     */
     private static $has_many = [
         'Galleries' => Gallery::class,
     ];
 
+    /**
+     * @var array
+     */
     private static $extensions = [
         Versioned::class,
     ];
 
-    private static $owns = [ 'Galleries' ];
+    /**
+     * @var array
+     */
+    private static $owns = [
+        'Galleries',
+    ];
 
+    /**
+     * @var string
+     */
     private static $table_name = 'SnapshotTest_Block';
 }

--- a/tests/SnapshotTest/BlockPage.php
+++ b/tests/SnapshotTest/BlockPage.php
@@ -1,28 +1,47 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Tests\SnapshotTest;
 
-use DNADesign\Elemental\Extensions\ElementalPageExtension;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\HasManyList;
 use SilverStripe\Versioned\Versioned;
 
+/**
+ * @method HasManyList|Block[] Blocks()
+ */
 class BlockPage extends DataObject implements TestOnly
 {
+    /**
+     * @var array
+     */
     private static $db = [
         'Title' => 'Varchar',
     ];
 
+    /**
+     * @var array
+     */
     private static $has_many = [
         'Blocks' => Block::class,
     ];
 
-    private static $owns = [ 'Blocks' ];
+    /**
+     * @var array
+     */
+    private static $owns = [
+        'Blocks',
+    ];
 
+    /**
+     * @var array
+     */
     private static $extensions = [
         Versioned::class,
     ];
 
+    /**
+     * @var string
+     */
     private static $table_name = 'SnapshotTest_BlockPage';
 }

--- a/tests/SnapshotTest/Gallery.php
+++ b/tests/SnapshotTest/Gallery.php
@@ -1,35 +1,61 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Tests\SnapshotTest;
 
+use SilverStripe\Assets\Image;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ManyManyThroughList;
 use SilverStripe\Versioned\Versioned;
 
+/**
+ * @property string $Title
+ * @property int $BlockID
+ * @method ManyManyThroughList|Image[] Images()
+ */
 class Gallery extends DataObject implements TestOnly
 {
+    /**
+     * @var array
+     */
     private static $db = [
         'Title' => 'Varchar',
     ];
 
+    /**
+     * @var array
+     */
     private static $has_one = [
         'Block' => Block::class,
     ];
 
+    /**
+     * @var array
+     */
     private static $many_many = [
         'Images' => [
             'through' => GalleryImageJoin::class,
             'from' => 'Gallery',
             'to' => 'Image',
-        ]
+        ],
     ];
 
+    /**
+     * @var array
+     */
     private static $extensions = [
         Versioned::class,
     ];
 
-    private static $owns = [ 'Images' ];
+    /**
+     * @var array
+     */
+    private static $owns = [
+        'Images',
+    ];
 
+    /**
+     * @var string
+     */
     private static $table_name = 'SnapshotTest_Gallery';
 }

--- a/tests/SnapshotTest/GalleryImage.php
+++ b/tests/SnapshotTest/GalleryImage.php
@@ -1,25 +1,39 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Tests\SnapshotTest;
 
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 
+/**
+ * @property string $URL
+ */
 class GalleryImage extends DataObject implements TestOnly
 {
+    /**
+     * @var array
+     */
     private static $db = [
         'URL' => 'Varchar',
     ];
 
+    /**
+     * @var array
+     */
     private static $belongs_many_many = [
         'Gallery' => Gallery::class,
     ];
 
+    /**
+     * @var array
+     */
     private static $extensions = [
         Versioned::class,
     ];
 
+    /**
+     * @var string
+     */
     private static $table_name = 'SnapshotTest_GalleryImage';
 }

--- a/tests/SnapshotTest/GalleryImageJoin.php
+++ b/tests/SnapshotTest/GalleryImageJoin.php
@@ -7,14 +7,23 @@ use SilverStripe\Versioned\Versioned;
 
 class GalleryImageJoin extends BaseJoin implements TestOnly
 {
+    /**
+     * @var array
+     */
     private static $has_one = [
         'Gallery' => Gallery::class,
         'Image' => GalleryImage::class,
     ];
 
+    /**
+     * @var array
+     */
     private static $extensions = [
         Versioned::class,
     ];
 
+    /**
+     * @var string
+     */
     private static $table_name = 'SnapshotTest_GalleryImageJoin';
 }

--- a/tests/SnapshotTestAbstract.php
+++ b/tests/SnapshotTestAbstract.php
@@ -1,20 +1,21 @@
 <?php
 
-
 namespace SilverStripe\Snapshots\Tests;
 
+use DateTime;
 use DNADesign\Elemental\Models\ElementalArea;
+use Exception;
+use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\SS_List;
+use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotEvent;
 use SilverStripe\Snapshots\SnapshotHasher;
 use SilverStripe\Snapshots\SnapshotItem;
-use DateTime;
 use SilverStripe\Snapshots\SnapshotPublishable;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BaseJoin;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
@@ -22,12 +23,19 @@ use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Gallery;
 use SilverStripe\Snapshots\Tests\SnapshotTest\GalleryImage;
 use SilverStripe\Snapshots\Tests\SnapshotTest\GalleryImageJoin;
+use SilverStripe\Versioned\RecursivePublishable;
 use SilverStripe\Versioned\Versioned;
 
 class SnapshotTestAbstract extends SapphireTest
 {
+    /**
+     * @var bool
+     */
     protected $usesDatabase = true;
 
+    /**
+     * @var array
+     */
     protected static $extra_dataobjects = [
         SnapshotItem::class,
         Snapshot::class,
@@ -41,6 +49,9 @@ class SnapshotTestAbstract extends SapphireTest
         SnapshotEvent::class,
     ];
 
+    /**
+     * @return PHPUnit_Framework_MockObject_MockObject|Snapshot
+     */
     protected function mockSnapshot()
     {
         $mock = $this->getMockBuilder(Snapshot::class)
@@ -56,6 +67,12 @@ class SnapshotTestAbstract extends SapphireTest
         return $mock;
     }
 
+    /**
+     * @param DataObject $obj
+     * @return Snapshot
+     * @throws ValidationException
+     * @throws Exception
+     */
     protected function createHistory(DataObject $obj): Snapshot
     {
         $snapshot = Snapshot::create();
@@ -72,18 +89,26 @@ class SnapshotTestAbstract extends SapphireTest
      *
      * @param int $minutes
      * @return string
+     * @throws Exception
      */
-    protected function sleep($minutes)
+    protected function sleep(int $minutes): string
     {
         $now = DBDatetime::now();
         $date = DateTime::createFromFormat('Y-m-d H:i:s', $now->getValue());
-        $date->modify("+{$minutes} minutes");
-        $stamp = $date->format('Y-m-d H:i:s');
-        DBDatetime::set_mock_now($stamp);
+        $date->modify(sprintf('+%d minutes', $minutes));
+        $dateTime = $date->format('Y-m-d H:i:s');
+        DBDatetime::set_mock_now($dateTime);
 
-        return $stamp;
+        return $dateTime;
     }
 
+    /**
+     * @param DataObject $obj
+     * @param array $extraObjects
+     * @return Snapshot
+     * @throws ValidationException
+     * @throws Exception
+     */
     protected function snapshot(DataObject $obj, array $extraObjects = []): Snapshot
     {
         $obj->write();
@@ -95,82 +120,107 @@ class SnapshotTestAbstract extends SapphireTest
         return $snapshot;
     }
 
+    /**
+     * @param DataObject|RecursivePublishable $obj
+     * @param array $extraObjects
+     * @return Snapshot
+     * @throws ValidationException
+     */
     protected function publish(DataObject $obj, array $extraObjects = []): Snapshot
     {
         $obj->publishRecursive();
         $obj = DataObject::get_by_id($obj->ClassName, $obj->ID, false);
         $snapshot = Snapshot::singleton()->createSnapshot($obj, $extraObjects);
+
         foreach ($snapshot->Items() as $item) {
             $item->WasPublished = 1;
         }
+
         $snapshot->write();
 
         return $snapshot;
     }
 
-    protected function buildState()
+    /**
+     * @return array
+     * @throws ValidationException
+     */
+    protected function buildState(): array
     {
-        /* @var DataObject|SnapshotPublishable $a1 */
-        $a1 = new BlockPage(['Title' => 'A1 Block Page']);
+        /** @var BlockPage|SnapshotPublishable $a1 */
+        $a1 = BlockPage::create();
+        $a1->Title = 'A1 Block Page';
         $this->snapshot($a1);
 
-        /* @var DataObject|SnapshotPublishable $a2 */
-        $a2 = new BlockPage(['Title' => 'A2 Block Page']);
+        /** @var BlockPage|SnapshotPublishable $a2 */
+        $a2 = BlockPage::create();
+        $a2->Title = 'A2 Block Page';
         $this->snapshot($a2);
 
-        /* @var DataObject|SnapshotPublishable $a1Block1 */
-        $a1Block1 = new Block(['Title' => 'Block 1 on A1', 'ParentID' => $a1->ID]);
+        /** @var Block|SnapshotPublishable $a1Block1 */
+        $a1Block1 = Block::create();
+        $a1Block1->Title = 'Block 1 on A1';
+        $a1Block1->ParentID = $a1->ID;
         $this->snapshot($a1Block1);
 
-        $a1Block2 = new Block(['Title' => 'Block 2 on A1', 'ParentID' => $a1->ID]);
+        $a1Block2 = Block::create();
+        $a1Block2->Title = 'Block 2 on A1';
+        $a1Block2->ParentID = $a1->ID;
         $this->snapshot($a1Block2);
 
-        /* @var DataObject|SnapshotPublishable $a2Block1 */
-        $a2Block1 = new Block(['Title' => 'Block 1 on A2', 'ParentID' => $a2->ID]);
+        /** @var Block|SnapshotPublishable $a2Block1 */
+        $a2Block1 = Block::create();
+        $a2Block1->Title = 'Block 1 on A2';
+        $a2Block1->ParentID = $a2->ID;
         $this->snapshot($a2Block1);
 
-        /* @var DataObject|SnapshotPublishable|Versioned $gallery1 */
-        $gallery1 = new Gallery(['Title' => 'Gallery 1 on Block 1 on A1', 'BlockID' => $a1Block1->ID]);
+        /** @var Gallery|SnapshotPublishable|Versioned $gallery1 */
+        $gallery1 = Gallery::create();
+        $gallery1->Title = 'Gallery 1 on Block 1 on A1';
+        $gallery1->BlockID = $a1Block1->ID;
         $this->snapshot($gallery1);
 
-        /* @var DataObject|SnapshotPublishable|Versioned $gallery1 */
-        $gallery2 = new Gallery(['Title' => 'Gallery 2 on Block 1 on A2', 'BlockID' => $a2Block1->ID]);
+        /** @var Gallery|SnapshotPublishable|Versioned $gallery1 */
+        $gallery2 = Gallery::create();
+        $gallery2->Title = 'Gallery 2 on Block 1 on A2';
+        $gallery2->BlockID = $a2Block1->ID;
         $this->snapshot($gallery2);
 
         return [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2];
     }
 
-    protected function assertItems(SS_List $result, array $objects, $column = 'ObjectHash')
+    protected function assertItems(SS_List $result, array $objects, string $column = 'ObjectHash'): void
     {
         $hashes = array_unique($result->column($column));
         $this->assertCount(count($objects), $hashes);
+
         foreach ($objects as $o) {
             $hash = SnapshotHasher::hashObjectForSnapshot($o);
             $this->assertTrue(in_array($hash, $hashes));
         }
     }
 
-    protected function assertObjects(SS_List $result, array $objects)
+    protected function assertObjects(SS_List $result, array $objects): void
     {
-        return $this->assertItems($result, $objects, 'ObjectHash');
+        $this->assertItems($result, $objects, 'ObjectHash');
     }
 
-    protected function assertOrigins(SS_List $result, array $objects)
+    protected function assertOrigins(SS_List $result, array $objects): void
     {
-        return $this->assertItems($result, $objects, 'OriginHash');
+        $this->assertItems($result, $objects, 'OriginHash');
     }
 
-    protected function assertHashCompare(DataObject $obj1, DataObject $obj2)
+    protected function assertHashCompare(DataObject $obj1, DataObject $obj2): void
     {
         $this->assertTrue(SnapshotHasher::hashSnapshotCompare($obj1, $obj2));
     }
 
-    protected function assertHashCompareList(array $objs1, array $objs2)
+    protected function assertHashCompareList(array $objs1, array $objs2): void
     {
-        $hashes1 = array_map(function ($o) {
+        $hashes1 = array_map(static function ($o) {
             return SnapshotHasher::hashObjectForSnapshot($o);
         }, $objs1);
-        $hashes2 = array_map(function ($o) {
+        $hashes2 = array_map(static function ($o) {
             return SnapshotHasher::hashObjectForSnapshot($o);
         }, $objs2);
         sort($hashes1);

--- a/tests/SnapshotTestAbstract.php
+++ b/tests/SnapshotTestAbstract.php
@@ -186,7 +186,15 @@ class SnapshotTestAbstract extends SapphireTest
         $gallery2->BlockID = $a2Block1->ID;
         $this->snapshot($gallery2);
 
-        return [$a1, $a2, $a1Block1, $a1Block2, $a2Block1, $gallery1, $gallery2];
+        return [
+            'a1' => $a1,
+            'a2' => $a2,
+            'a1Block1' => $a1Block1,
+            'a1Block2' => $a1Block2,
+            'a2Block1' => $a2Block1,
+            'gallery1' => $gallery1,
+            'gallery2' => $gallery2,
+        ];
     }
 
     protected function assertItems(SS_List $result, array $objects, string $column = 'ObjectHash'): void


### PR DESCRIPTION
# NEW: Code cleanup (tests, linting).

* Travis automated tests run setup
* Composer configuration update to cover the needed dependencies to run tests
* Linting fixes
* Fixed two tests which were broken before this change-set
* No functional or behavioural changes
* PHP 8 compatibility fixes

## Out of scope of this PR

* [Static methods](https://github.com/silverstripe/silverstripe-versioned-snapshots/pull/55)
* Raw queries
* Deep integration

These will be covered separate change-sets

## Related issues

https://github.com/silverstripe/silverstripe-versioned-snapshots/issues/51