### PR TITLE
NEW: Static methods replaced with non-static singleton pattern.

### DIFF
--- a/src/Handler/Elemental/ArchiveElementHandler.php
+++ b/src/Handler/Elemental/ArchiveElementHandler.php
@@ -42,7 +42,7 @@ class ArchiveElementHandler extends Handler
             return null;
         }
 
-        $archivedBlock = SnapshotPublishable::get_at_last_snapshot(BaseElement::class, $blockID);
+        $archivedBlock = SnapshotPublishable::singleton()->getAtLastSnapshotByClassAndId(BaseElement::class, $blockID);
 
         if (!$archivedBlock) {
             return null;

--- a/src/Handler/Elemental/ModifyElementHandler.php
+++ b/src/Handler/Elemental/ModifyElementHandler.php
@@ -50,7 +50,7 @@ class ModifyElementHandler extends Handler
         }
 
         foreach ($snapshot->Items() as $item) {
-            if (!static::hashSnapshotCompare($item->getItem(), $block)) {
+            if (!$this->hashSnapshotCompare($item->getItem(), $block)) {
                 continue;
             }
 

--- a/src/Handler/Form/UnpublishHandler.php
+++ b/src/Handler/Form/UnpublishHandler.php
@@ -26,7 +26,7 @@ class UnpublishHandler extends Handler
         }
 
         foreach ($snapshot->Items() as $item) {
-            if (!static::hashSnapshotCompare($item->getItem(), $record)) {
+            if (!$this->hashSnapshotCompare($item->getItem(), $record)) {
                 continue;
             }
 

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -207,7 +207,7 @@ class Snapshot extends DataObject
             return false;
         }
 
-        $liveVersionNumber = SnapshotPublishable::get_published_version_number(
+        $liveVersionNumber = SnapshotPublishable::singleton()->getPublishedVersionNumber(
             $originVersion->baseClass(),
             $originVersion->ID
         );
@@ -217,7 +217,7 @@ class Snapshot extends DataObject
             ->setFrom("\"$table\"")
             ->addWhere([
                 "\"$table\".\"Version\" = ?" => $liveVersionNumber,
-                "\"$table\".\"ObjectHash\" = ?" => static::hashObjectForSnapshot($originVersion),
+                "\"$table\".\"ObjectHash\" = ?" => $this->hashObjectForSnapshot($originVersion),
             ])
             ->execute()
             ->value();
@@ -283,7 +283,7 @@ class Snapshot extends DataObject
     {
         parent::onBeforeWrite();
 
-        $this->OriginHash = static::hashForSnapshot($this->OriginClass, $this->OriginID);
+        $this->OriginHash = $this->hashForSnapshot($this->OriginClass, $this->OriginID);
     }
 
     /**

--- a/src/SnapshotHasher.php
+++ b/src/SnapshotHasher.php
@@ -16,7 +16,7 @@ trait SnapshotHasher
      * @param int|null $id
      * @return string
      */
-    public static function hashForSnapshot(?string $class, ?int $id): string
+    public function hashForSnapshot(?string $class, ?int $id): string
     {
         return md5(sprintf('%s:%s', $class, $id));
     }
@@ -27,9 +27,9 @@ trait SnapshotHasher
      * @param DataObject $obj
      * @return string
      */
-    public static function hashObjectForSnapshot(DataObject $obj): string
+    public function hashObjectForSnapshot(DataObject $obj): string
     {
-        return static::hashForSnapshot($obj->baseClass(), $obj->ID);
+        return $this->hashForSnapshot($obj->baseClass(), $obj->ID);
     }
 
     /**
@@ -37,8 +37,8 @@ trait SnapshotHasher
      * @param DataObject $obj2
      * @return bool
      */
-    public static function hashSnapshotCompare(DataObject $obj1, DataObject $obj2): bool
+    public function hashSnapshotCompare(DataObject $obj1, DataObject $obj2): bool
     {
-        return static::hashObjectForSnapshot($obj1) === static::hashObjectForSnapshot($obj2);
+        return $this->hashObjectForSnapshot($obj1) === $this->hashObjectForSnapshot($obj2);
     }
 }

--- a/src/SnapshotItem.php
+++ b/src/SnapshotItem.php
@@ -166,7 +166,7 @@ class SnapshotItem extends DataObject
     {
         parent::onBeforeWrite();
 
-        $this->ObjectHash = static::hashForSnapshot($this->ObjectClass, $this->ObjectID);
+        $this->ObjectHash = $this->hashForSnapshot($this->ObjectClass, $this->ObjectID);
     }
 
     /**
@@ -217,7 +217,7 @@ class SnapshotItem extends DataObject
         } else {
             // Track publish state for non-versioned owners, they're always in a published state.
             $exists = SnapshotItem::get()->filter([
-                'ObjectHash' => static::hashObjectForSnapshot($object)
+                'ObjectHash' => $this->hashObjectForSnapshot($object)
             ]);
             $this->WasCreated = !$exists->exists();
             $this->WasPublished = true;

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1489,11 +1489,11 @@ class IntegrationTest extends SnapshotTestAbstract
             }
 
             $expectedHash = $obj->isInDB()
-                ? SnapshotPublishable::hashObjectForSnapshot($obj)
-                : SnapshotPublishable::hashForSnapshot($obj->ClassName, $obj->OldID);
+                ? SnapshotPublishable::singleton()->hashObjectForSnapshot($obj)
+                : SnapshotPublishable::singleton()->hashForSnapshot($obj->ClassName, $obj->OldID);
             $this->assertEquals(
                 $expectedHash,
-                SnapshotPublishable::hashObjectForSnapshot($entry->Subject)
+                SnapshotPublishable::singleton()->hashObjectForSnapshot($entry->Subject)
             );
             $this->assertEquals($action, $entry->Action);
         }
@@ -1512,11 +1512,11 @@ class IntegrationTest extends SnapshotTestAbstract
 
             $obj= $objs[$i];
             $expectedHash = $obj->isInDB()
-                ? SnapshotPublishable::hashObjectForSnapshot($obj)
-                : SnapshotPublishable::hashForSnapshot($obj->ClassName, $obj->OldID);
+                ? SnapshotPublishable::singleton()->hashObjectForSnapshot($obj)
+                : SnapshotPublishable::singleton()->hashForSnapshot($obj->ClassName, $obj->OldID);
             $this->assertEquals(
                 $expectedHash,
-                SnapshotPublishable::hashObjectForSnapshot($dataObject)
+                SnapshotPublishable::singleton()->hashObjectForSnapshot($dataObject)
             );
         }
     }

--- a/tests/SnapshotItemTest.php
+++ b/tests/SnapshotItemTest.php
@@ -4,8 +4,8 @@ namespace SilverStripe\Snapshots\Tests;
 
 use Exception;
 use SilverStripe\ORM\ValidationException;
-use SilverStripe\Snapshots\SnapshotHasher;
 use SilverStripe\Snapshots\SnapshotItem;
+use SilverStripe\Snapshots\SnapshotPublishable;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
 use SilverStripe\Versioned\Versioned;
 
@@ -49,7 +49,7 @@ class SnapshotItemTest extends SnapshotTestAbstract
         $this->assertEquals(Block::class, $item->ObjectClass);
         $this->assertEquals($block->ID, $item->ObjectID);
         $this->assertEquals($block->Version, $item->Version);
-        $this->assertEquals(SnapshotHasher::hashObjectForSnapshot($block), $item->ObjectHash);
+        $this->assertEquals(SnapshotPublishable::singleton()->hashObjectForSnapshot($block), $item->ObjectHash);
 
         $this->assertTrue($item->WasDraft);
         $this->assertFalse($item->WasDeleted);

--- a/tests/SnapshotPublishableTest.php
+++ b/tests/SnapshotPublishableTest.php
@@ -25,7 +25,8 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $a1 = $state['a1'];
 
         $firstSnapshot = Snapshot::get()->sort('Created ASC')->first();
-        $result = SnapshotPublishable::get_at_snapshot(BlockPage::class, $a1->ID, $firstSnapshot->Created);
+        $result = SnapshotPublishable::singleton()
+            ->getAtSnapshotByClassAndId(BlockPage::class, $a1->ID, $firstSnapshot->Created);
 
         $param = $result->getSourceQueryParam('Versioned.date');
         $this->assertNotNull($param);
@@ -44,7 +45,7 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $a1->Title = 'changed';
         $a1->write();
 
-        $result = SnapshotPublishable::get_at_last_snapshot(BlockPage::class, $a1->ID);
+        $result = SnapshotPublishable::singleton()->getAtLastSnapshotByClassAndId(BlockPage::class, $a1->ID);
         $this->assertNotNull($result);
         $this->assertEquals('A1 Block Page', $result->Title);
     }
@@ -61,7 +62,7 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->snapshot($a1);
 
         /** @var DataObject|Versioned $result */
-        $result = SnapshotPublishable::get_last_snapshot_item(BlockPage::class, $a1->ID);
+        $result = SnapshotPublishable::singleton()->getLastSnapshotItemByClassAndId(BlockPage::class, $a1->ID);
         $this->assertNotNull($result);
         $this->assertEquals($a1->Version, $result->Version);
     }
@@ -72,7 +73,7 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
     public function testGetSnapshots(): void
     {
         $state = $this->buildState();
-        $snapshots = SnapshotPublishable::getSnapshots();
+        $snapshots = SnapshotPublishable::singleton()->getSnapshots();
         $this->assertOrigins($snapshots, $state);
     }
 

--- a/tests/SnapshotTestAbstract.php
+++ b/tests/SnapshotTestAbstract.php
@@ -14,7 +14,6 @@ use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotEvent;
-use SilverStripe\Snapshots\SnapshotHasher;
 use SilverStripe\Snapshots\SnapshotItem;
 use SilverStripe\Snapshots\SnapshotPublishable;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BaseJoin;
@@ -203,7 +202,7 @@ class SnapshotTestAbstract extends SapphireTest
         $this->assertCount(count($objects), $hashes);
 
         foreach ($objects as $o) {
-            $hash = SnapshotHasher::hashObjectForSnapshot($o);
+            $hash = SnapshotPublishable::singleton()->hashObjectForSnapshot($o);
             $this->assertTrue(in_array($hash, $hashes));
         }
     }
@@ -220,16 +219,16 @@ class SnapshotTestAbstract extends SapphireTest
 
     protected function assertHashCompare(DataObject $obj1, DataObject $obj2): void
     {
-        $this->assertTrue(SnapshotHasher::hashSnapshotCompare($obj1, $obj2));
+        $this->assertTrue(SnapshotPublishable::singleton()->hashSnapshotCompare($obj1, $obj2));
     }
 
     protected function assertHashCompareList(array $objs1, array $objs2): void
     {
         $hashes1 = array_map(static function ($o) {
-            return SnapshotHasher::hashObjectForSnapshot($o);
+            return SnapshotPublishable::singleton()->hashObjectForSnapshot($o);
         }, $objs1);
         $hashes2 = array_map(static function ($o) {
-            return SnapshotHasher::hashObjectForSnapshot($o);
+            return SnapshotPublishable::singleton()->hashObjectForSnapshot($o);
         }, $objs2);
         sort($hashes1);
         sort($hashes2);


### PR DESCRIPTION
# NEW: Static methods replaced with non-static singleton pattern.

* Static methods replaced with non-static singleton pattern
* Minor code cleanup of in-memory cache but still left it disabled

## Out of scope of this PR

* Raw queries
* Deep integration

These will be covered separate change-sets

## Related issues

https://github.com/silverstripe/silverstripe-versioned-snapshots/issues/51