### PR TITLE
# BUG: Fluent module compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,29 @@ As mentioned above, elements all receive `snapshot_relation_tracking` on their p
 Another module that is supported out of the box is [GridFieldExtensions](https://github.com/symbiote/silverstripe-gridfieldextensions). A handler is provided
 for its `GridFieldOrderableRows` component.
 
+## Localisation
+
+This module can be configured to work with the [Fluent](https://github.com/tractorcow-farm/silverstripe-fluent) module.
+Following the paradigm set by the Fluent version history, we do not allow any content inheritance when it comes to versioned history.
+Our `Snapshot` and `SnpashotItem` models represent a more detailed version history, so we need to apply the following configuration to comply with the Fluent paradigm:
+
+```yaml
+SilverStripe\Snapshots\Snapshot:
+    cms_localisation_required: 'exact'
+    frontend_publish_required: 'exact'
+    extensions:
+        - TractorCow\Fluent\Extension\FluentExtension
+    translate:
+        - OriginHash
+
+SilverStripe\Snapshots\SnapshotItem:
+    cms_localisation_required: 'exact'
+    frontend_publish_required: 'exact'
+    extensions:
+        - TractorCow\Fluent\Extension\FluentExtension
+    translate:
+        - ObjectHash
+```
 
 ## Semantic versioning
 

--- a/src/ActivityEntry.php
+++ b/src/ActivityEntry.php
@@ -61,8 +61,8 @@ class ActivityEntry extends ArrayData
                 $itemObj = $item->getItem($previousVersion->Version);
             // This is to deal with the case in which there is no previous version
             // it's better to give a faulty snapshot point than break the app
-            } elseif ($item->Version > 1) {
-                $itemObj = $item->getItem($item->Version - 1);
+            } elseif ($item->ObjectVersion > 1) {
+                $itemObj = $item->getItem($item->ObjectVersion - 1);
             }
         }
 

--- a/src/Migration/MigrationService.php
+++ b/src/Migration/MigrationService.php
@@ -182,7 +182,7 @@ SQL;
             (
                 \"Created\",
                 \"LastEdited\",
-                \"Version\",
+                \"ObjectVersion\",
                 \"WasPublished\",
                 \"WasDraft\",
                 \"WasDeleted\",

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -154,7 +154,7 @@ class Snapshot extends DataObject
             return Versioned::get_version(
                 $originItem->ObjectClass,
                 $originItem->ObjectID,
-                $originItem->Version
+                $originItem->ObjectVersion
             );
         }
 
@@ -211,7 +211,7 @@ class Snapshot extends DataObject
 
         $latestPublishID = SnapshotItem::get()
             ->filter([
-                'Version' => $liveVersionNumber,
+                'ObjectVersion' => $liveVersionNumber,
                 'ObjectHash' => $this->hashObjectForSnapshot($originVersion),
             ])
             ->max('SnapshotID');

--- a/src/SnapshotItem.php
+++ b/src/SnapshotItem.php
@@ -14,7 +14,7 @@ use SilverStripe\Versioned\Versioned;
 /**
  * Class SnapshotItem
  *
- * @property int $Version
+ * @property int $ObjectVersion
  * @property int $WasPublished
  * @property int $WasUnpublished
  * @property int $WasCreated
@@ -40,7 +40,7 @@ class SnapshotItem extends DataObject
      * @var array
      */
     private static $db = [
-        'Version' => 'Int',
+        'ObjectVersion' => 'Int',
         'WasPublished' => 'Boolean',
         'WasDraft' => 'Boolean',
         'WasDeleted' => 'Boolean',
@@ -70,7 +70,7 @@ class SnapshotItem extends DataObject
      * @var array
      */
     private static $indexes = [
-        'Version' => true,
+        'ObjectVersion' => true,
         'ObjectHash' => true,
         'Object' => [
             'columns' => ['ObjectHash', 'SnapshotID'],
@@ -183,7 +183,7 @@ class SnapshotItem extends DataObject
      */
     public function getItem(?int $version = null): ?DataObject
     {
-        $version = $version ?? $this->Version;
+        $version = $version ?? $this->ObjectVersion;
 
         return Versioned::get_all_versions($this->ObjectClass, $this->ObjectID)
             ->find('Version', $version);
@@ -218,7 +218,7 @@ class SnapshotItem extends DataObject
             $this->WasPublished = false;
             $this->WasDraft = $object->isModifiedOnDraft();
             $this->WasDeleted = $object->isOnLiveOnly() || $object->isArchived();
-            $this->Version = $object->Version;
+            $this->ObjectVersion = $object->Version;
         } else {
             // Track publish state for non-versioned owners, they're always in a published state.
             $exists = SnapshotItem::get()->filter([

--- a/src/SnapshotPublishable.php
+++ b/src/SnapshotPublishable.php
@@ -168,7 +168,7 @@ class SnapshotPublishable extends RecursivePublishable implements Resettable
         $lastPublishedSnapshotID = (int) SnapshotItem::get()
             ->filter([
                 'ObjectHash' => $this->hashObjectForSnapshot($this->owner),
-                'Version' => $sinceVersion,
+                'ObjectVersion' => $sinceVersion,
                 'WasPublished' => 1,
             ])
             ->max('SnapshotID');
@@ -177,7 +177,7 @@ class SnapshotPublishable extends RecursivePublishable implements Resettable
             ->getRelevantSnapshots()
             ->filter([
                 // last published version
-                'Items.Version:GreaterThanOrEqual' => $sinceVersion,
+                'Items.ObjectVersion:GreaterThanOrEqual' => $sinceVersion,
                 // is not a snapshot of the last publishing
                 'ID:GreaterThan' => $lastPublishedSnapshotID,
             ]);
@@ -210,14 +210,14 @@ class SnapshotPublishable extends RecursivePublishable implements Resettable
         $minSnapshotID = (int) SnapshotItem::get()
             ->filter([
                 'ObjectHash' => $hash,
-                'Version' => $min,
+                'ObjectVersion' => $min,
             ])
             ->min('SnapshotID');
 
         $maxSnapshotID = (int) SnapshotItem::get()
             ->filter([
                 'ObjectHash' => $hash,
-                'Version' => $max,
+                'ObjectVersion' => $max,
             ])
             ->max('SnapshotID');
 
@@ -237,7 +237,7 @@ class SnapshotPublishable extends RecursivePublishable implements Resettable
         return SnapshotItem::get()
             ->filter($filters)
             ->filterAny([
-                'Version:Not' => $min,
+                'ObjectVersion:Not' => $min,
                 'WasPublished' => 0,
             ]);
     }
@@ -421,7 +421,7 @@ class SnapshotPublishable extends RecursivePublishable implements Resettable
      */
     public function isModifiedSinceLastSnapshot(): bool
     {
-        /** @var SnapshotItem $previous */
+        /** @var DataObject|Versioned $previous */
         $previous = $this->getPreviousSnapshotVersion();
 
         return !$previous || $previous->Version < $this->owner->Version;

--- a/tests/SnapshotItemTest.php
+++ b/tests/SnapshotItemTest.php
@@ -19,15 +19,14 @@ class SnapshotItemTest extends SnapshotTestAbstract
         /** @var Block|Versioned $block */
         $block = Block::create();
         $block->write();
-        $item = SnapshotItem::create([
-            'ObjectClass' => Block::class,
-            'ObjectID' => $block->ID,
-            'Version' => $block->Version * 100,
-        ]);
+        $item = SnapshotItem::create();
+        $item->ObjectClass = Block::class;
+        $item->ObjectID = $block->ID;
+        $item->ObjectVersion = $block->Version * 100;
 
         $this->assertNull($item->getItem());
 
-        $item->Version = $block->Version;
+        $item->ObjectVersion = $block->Version;
 
         $this->assertInstanceOf(Block::class, $item->getItem());
         $this->assertEquals($block->ID, $item->getItem()->ID);
@@ -48,7 +47,7 @@ class SnapshotItemTest extends SnapshotTestAbstract
         $item->write();
         $this->assertEquals(Block::class, $item->ObjectClass);
         $this->assertEquals($block->ID, $item->ObjectID);
-        $this->assertEquals($block->Version, $item->Version);
+        $this->assertEquals($block->Version, $item->ObjectVersion);
         $this->assertEquals(SnapshotPublishable::singleton()->hashObjectForSnapshot($block), $item->ObjectHash);
 
         $this->assertTrue($item->WasDraft);

--- a/tests/SnapshotPublishableTest.php
+++ b/tests/SnapshotPublishableTest.php
@@ -7,6 +7,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Snapshot;
+use SilverStripe\Snapshots\SnapshotItem;
 use SilverStripe\Snapshots\SnapshotPublishable;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
@@ -61,10 +62,10 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $a1->Title = 'changed';
         $this->snapshot($a1);
 
-        /** @var DataObject|Versioned $result */
+        /** @var SnapshotItem $result */
         $result = SnapshotPublishable::singleton()->getLastSnapshotItemByClassAndId(BlockPage::class, $a1->ID);
         $this->assertNotNull($result);
-        $this->assertEquals($a1->Version, $result->Version);
+        $this->assertEquals($a1->Version, $result->ObjectVersion);
     }
 
     /**
@@ -307,7 +308,7 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->snapshot($a1);
         $version = Versioned::get_versionnumber_by_stage(BlockPage::class, Versioned::DRAFT, $a1->ID);
         $item = $a1->getPreviousSnapshotItem();
-        $this->assertEquals($version, $item->Version);
+        $this->assertEquals($version, $item->ObjectVersion);
         $this->assertHashCompare($a1, $item->getItem());
     }
 

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -147,7 +147,7 @@ class SnapshotTest extends SnapshotTestAbstract
         $item->ObjectClass = $block1->baseClass();
         $item->ObjectID = $block1->ID;
         $item->SnapshotID = $snapshot->ID;
-        $item->Version = $block1->Version;
+        $item->ObjectVersion = $block1->Version;
         $item->write();
 
         /** @var Block|Versioned $block2 */
@@ -163,7 +163,7 @@ class SnapshotTest extends SnapshotTestAbstract
         $item->ObjectClass = $block2->baseClass();
         $item->ObjectID = $block2->ID;
         $item->SnapshotID = $snapshot->ID;
-        $item->Version = $expectedVersion;
+        $item->ObjectVersion = $expectedVersion;
         $item->write();
 
         $snapshot->OriginClass = $item->ObjectClass;


### PR DESCRIPTION
# BUG: Fluent module compatibility

Compatibility changes for Fluent module. Instructions for Fluent module integration added to the docs.

## Rename Version field to ObjectVersion to prevent conflicts with reserved field

`Version` is a special model property that should not be redefined on any model. `SnapshotItem` currently has a `Version` property which may cause some random issues (especially when forceChange() is called). This change renames `Version` to `ObjectVersion` to prevent random issues and it's also more accurate as the version refers to the related object not the item itself.

## Compatibility

This represents a breaking change which is acceptable as this is part of a new major version.