### PR TITLE
NEW: In-memory cache for relation differ.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -12,6 +12,9 @@ SilverStripe\Versioned\ChangeSetItem:
 SilverStripe\Dev\CsvBulkLoader:
   extensions:
     - SilverStripe\Snapshots\CsvBulkLoader\SaveListener
+SilverStripe\ORM\DataObject:
+  extensions:
+    - SilverStripe\Snapshots\RelationDiffer\ClearCacheExtension
 ---
 Name: snapshot-migration
 ---

--- a/src/Handler/Elemental/PageSaveHandler.php
+++ b/src/Handler/Elemental/PageSaveHandler.php
@@ -9,7 +9,7 @@ use Exception;
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\Form\SaveHandler;
-use SilverStripe\Snapshots\RelationDiffer;
+use SilverStripe\Snapshots\RelationDiffer\RelationDiffer;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotPublishable;
 

--- a/src/ImplicitModification.php
+++ b/src/ImplicitModification.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Snapshots;
 
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Snapshots\RelationDiffer\RelationDiffer;
 
 class ImplicitModification extends SnapshotEvent
 {

--- a/src/RelationDiffer/ClearCacheExtension.php
+++ b/src/RelationDiffer/ClearCacheExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\Snapshots\RelationDiffer;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * Clear in-memory cache when DB update is executed
+ *
+ * @method DataObject|$this getOwner()
+ */
+class ClearCacheExtension extends Extension
+{
+    public function onAfterWrite(): void
+    {
+        RelationDiffCache::reset();
+    }
+}

--- a/src/RelationDiffer/RelationDiffCache.php
+++ b/src/RelationDiffer/RelationDiffCache.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SilverStripe\Snapshots\RelationDiffer;
+
+use Exception;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Resettable;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Snapshots\SnapshotHasher;
+
+/**
+ * In-memory cache for relation diffs
+ */
+class RelationDiffCache implements Resettable
+{
+
+    use Injectable;
+    use SnapshotHasher;
+
+    /**
+     * @var array
+     */
+    protected $cachedData = [];
+
+    /**
+     * @param DataObject $object
+     * @return array|null
+     * @throws Exception
+     */
+    public function getCachedData(DataObject $object): ?array
+    {
+        $key = $this->getCacheKey($object);
+
+        // Invalid cache key
+        if (!$key) {
+            return null;
+        }
+
+        if (array_key_exists($key, $this->cachedData)) {
+            return $this->cachedData[$key];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param DataObject $object
+     * @param array $data
+     * @return $this
+     * @throws Exception
+     */
+    public function addCachedData(DataObject $object, array $data): self
+    {
+        $key = $this->getCacheKey($object);
+
+        // Invalid cache key
+        if (!$key) {
+            return $this;
+        }
+
+        $this->cachedData[$key] = $data;
+
+        return $this;
+    }
+
+    public function flushCachedData(): void
+    {
+        $this->cachedData = [];
+    }
+
+    public static function reset(): void
+    {
+        static::singleton()->flushCachedData();
+    }
+
+    /**
+     * @param DataObject $object
+     * @return string
+     * @throws Exception
+     */
+    protected function getCacheKey(DataObject $object): string
+    {
+        return $object->isInDB()
+            ? sprintf(
+                '%s-%s',
+                $object->getUniqueKey(),
+                $this->hashObjectForSnapshot($object)
+            )
+            : '';
+    }
+}

--- a/src/RelationDiffer/RelationDiffer.php
+++ b/src/RelationDiffer/RelationDiffer.php
@@ -1,14 +1,16 @@
 <?php
 
-namespace SilverStripe\Snapshots;
+namespace SilverStripe\Snapshots\RelationDiffer;
 
 use InvalidArgumentException;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Snapshots\SnapshotPublishable;
 
 class RelationDiffer
 {
+
     use Injectable;
 
     /**

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -9,6 +9,7 @@ use SilverStripe\ORM\ValidationException;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
+use SilverStripe\Snapshots\RelationDiffer\RelationDiffer;
 use SilverStripe\Versioned\Versioned;
 
 /**

--- a/tests/Handler/Elemental/PageSaveHandlerTest.php
+++ b/tests/Handler/Elemental/PageSaveHandlerTest.php
@@ -12,7 +12,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Handler\Elemental\PageSaveHandler;
-use SilverStripe\Snapshots\RelationDiffer;
+use SilverStripe\Snapshots\RelationDiffer\RelationDiffer;
 use SilverStripe\Snapshots\SnapshotPublishable;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
 use SilverStripe\Snapshots\Tests\SnapshotTestAbstract;

--- a/tests/RelationDifferTest.php
+++ b/tests/RelationDifferTest.php
@@ -4,7 +4,7 @@ namespace SilverStripe\Snapshots\Tests;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ValidationException;
-use SilverStripe\Snapshots\RelationDiffer;
+use SilverStripe\Snapshots\RelationDiffer\RelationDiffer;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
 use SilverStripe\Versioned\Versioned;
 


### PR DESCRIPTION
# NEW: In-memory cache for relation differ

* In-memory cache for relation differ
* finishing incomplete implementation of in-memory cache
* unit tests cover both cache hits & misses
* minor code cleanup