### PR TITLE
Bugfix: CSVBulkLoader handler hook check

### DIFF
--- a/src/Handler/CsvBulkLoader/Handler.php
+++ b/src/Handler/CsvBulkLoader/Handler.php
@@ -6,6 +6,7 @@ namespace SilverStripe\Snapshots\Handler\CsvBulkLoader;
 use SilverStripe\EventDispatcher\Event\EventContextInterface;
 use SilverStripe\Snapshots\Handler\HandlerAbstract;
 use SilverStripe\Snapshots\Snapshot;
+use SilverStripe\Versioned\Versioned;
 
 class Handler extends HandlerAbstract
 {
@@ -20,6 +21,10 @@ class Handler extends HandlerAbstract
 
         if (!$obj) {
             throw new \InvalidArgumentException('Requires "record" in context');
+        }
+
+        if (!$obj->hasExtension(Versioned::class)) {
+            return null;
         }
 
         // Create an individual snapshot for each object to ensure they're all captured.


### PR DESCRIPTION
Because the new CSVBulkLoader handler does not use `hasExtension()` hook with `Versioned::class` this means any `DataObject::class` would then call `createSnapShot()` and thus fail when it realised it does not have a versioned record.

This change simply checks versioned is applied to the object and returns null if falsey.