### PR TITLE
BUG: Origin versioned check.

### DIFF
--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -296,6 +296,11 @@ class Snapshot extends DataObject
             return null;
         }
 
+        if (!$origin->hasExtension(Versioned::class)) {
+            // We require origin to be versioned, if it's not we can bail out
+            return null;
+        }
+
         $currentUser = Security::getCurrentUser();
         $snapshot = Snapshot::create();
         $snapshot->AuthorID = $currentUser

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -8,10 +8,12 @@ use SilverStripe\ORM\ValidationException;
 use SilverStripe\Snapshots\Snapshot;
 use SilverStripe\Snapshots\SnapshotEvent;
 use SilverStripe\Snapshots\SnapshotItem;
+use SilverStripe\Snapshots\SnapshotPublishable;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Block;
 use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Gallery;
 use SilverStripe\Snapshots\Tests\SnapshotTest\GalleryImage;
+use SilverStripe\Snapshots\Tests\SnapshotTest\SimpleBlock;
 use SilverStripe\Versioned\Versioned;
 
 class SnapshotTest extends SnapshotTestAbstract
@@ -426,5 +428,21 @@ class SnapshotTest extends SnapshotTestAbstract
 
         $this->assertCount(1, $liveSnapshots);
         $this->assertEquals(Snapshot::get()->max('ID'), $liveSnapshots[0]->ID);
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    public function testUnVersionedObject(): void
+    {
+        $block = SimpleBlock::create();
+        $block->Title = 'Simple block';
+        $block->write();
+
+        $this->assertTrue($block->hasExtension(SnapshotPublishable::class));
+        $this->assertFalse($block->hasExtension(Versioned::class));
+
+        $snapshot = Snapshot::singleton()->createSnapshot($block);
+        $this->assertNull($snapshot, 'We expect no snapshot for models which are not versioned');
     }
 }

--- a/tests/SnapshotTest/SimpleBlock.php
+++ b/tests/SnapshotTest/SimpleBlock.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\Snapshots\Tests\SnapshotTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * @property string $Title
+ */
+class SimpleBlock extends DataObject implements TestOnly
+{
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
+
+    /**
+     * @var string
+     */
+    private static $table_name = 'SnapshotTest_SimpleBlock';
+}

--- a/tests/SnapshotTestAbstract.php
+++ b/tests/SnapshotTestAbstract.php
@@ -22,6 +22,7 @@ use SilverStripe\Snapshots\Tests\SnapshotTest\BlockPage;
 use SilverStripe\Snapshots\Tests\SnapshotTest\Gallery;
 use SilverStripe\Snapshots\Tests\SnapshotTest\GalleryImage;
 use SilverStripe\Snapshots\Tests\SnapshotTest\GalleryImageJoin;
+use SilverStripe\Snapshots\Tests\SnapshotTest\SimpleBlock;
 use SilverStripe\Versioned\RecursivePublishable;
 use SilverStripe\Versioned\Versioned;
 
@@ -46,6 +47,7 @@ class SnapshotTestAbstract extends SapphireTest
         BaseJoin::class,
         GalleryImageJoin::class,
         SnapshotEvent::class,
+        SimpleBlock::class,
     ];
 
     /**


### PR DESCRIPTION
# Origin versioned check

Un-versioned origin objects need to bail out during the snapshot creation.

Replaces https://github.com/silverstripe/silverstripe-versioned-snapshots/pull/58