### PR TITLE
MISC: Extensions config cleanup.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -8,13 +8,13 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\Snapshots\SnapshotPublishable
 SilverStripe\Versioned\ChangeSetItem:
   extensions:
-    - SilverStripe\Snapshots\SnapshotChangeSetItem
+    SnapshotChangeSetItem: SilverStripe\Snapshots\SnapshotChangeSetItem
 SilverStripe\Dev\CsvBulkLoader:
   extensions:
-    - SilverStripe\Snapshots\CsvBulkLoader\SaveListener
+    SnapshotsSaveListener: SilverStripe\Snapshots\CsvBulkLoader\SaveListener
 SilverStripe\ORM\DataObject:
   extensions:
-    - SilverStripe\Snapshots\RelationDiffer\ClearCacheExtension
+    SnapshotsClearCacheExtension: SilverStripe\Snapshots\RelationDiffer\ClearCacheExtension
 ---
 Name: snapshot-migration
 ---
@@ -37,4 +37,4 @@ Only:
 ---
 SilverStripe\CMS\Model\SiteTree:
   extensions:
-    - SilverStripe\Snapshots\SnapshotSiteTree
+    SnapshotSiteTree: SilverStripe\Snapshots\SnapshotSiteTree

--- a/_config/elemental.yml
+++ b/_config/elemental.yml
@@ -5,7 +5,7 @@ Only:
 ---
 DNADesign\Elemental\Forms\ElementalAreaField:
   extensions:
-    - SilverStripe\Snapshots\Elemental\SaveListener
+    SnapshotsSaveListener: SilverStripe\Snapshots\Elemental\SaveListener
 DNADesign\Elemental\Models\ElementalArea:
   snapshot_relation_tracking:
     - Elements

--- a/_config/thirdparty.yml
+++ b/_config/thirdparty.yml
@@ -37,7 +37,7 @@ Only:
 ---
 SilverStripe\ORM\DataObject:
   extensions:
-    - SilverStripe\Snapshots\Thirdparty\EmbargoExpiryExtension
+    SnapshotsEmbargoExpiryExtension: SilverStripe\Snapshots\Thirdparty\EmbargoExpiryExtension
 SilverStripe\Core\Injector\Injector:
   SilverStripe\EventDispatcher\Dispatch\Dispatcher:
     properties:
@@ -57,4 +57,4 @@ Only:
 ---
 SilverStripe\Admin\Forms\UsedOnTable:
   extensions:
-    - SilverStripe\Snapshots\Thirdparty\UsedOnTableExtension
+    SnapshotsUsedOnTableExtension: SilverStripe\Snapshots\Thirdparty\UsedOnTableExtension

--- a/_config/workflow.yml
+++ b/_config/workflow.yml
@@ -5,10 +5,10 @@ Only:
 ---
 Symbiote\AdvancedWorkflow\Actions\PublishItemWorkflowAction:
   extensions:
-    - SilverStripe\Snapshots\Workflow\WorkflowExtension
+    SnapshotsWorkflowExtension: SilverStripe\Snapshots\Workflow\WorkflowExtension
 Symbiote\AdvancedWorkflow\Jobs\WorkflowPublishTargetJob:
-   extensions:
-     - SilverStripe\Snapshots\Workflow\WorkflowExtension
+  extensions:
+    SnapshotsWorkflowExtension: SilverStripe\Snapshots\Workflow\WorkflowExtension
 
 SilverStripe\Core\Injector\Injector:
   SilverStripe\EventDispatcher\Dispatch\Dispatcher:

--- a/src/Handler/GridField/Action/ReorderHandler.php
+++ b/src/Handler/GridField/Action/ReorderHandler.php
@@ -31,13 +31,12 @@ class ReorderHandler extends Handler
 
         $model = $grid->getModelClass();
         $pluralName = DataObject::singleton($model)->i18n_plural_name();
-        $event = SnapshotEvent::create([
-            'Title' => _t(
-                self::class . '.REORDER_ROWS',
-                'Reordered {title}',
-                ['title' => $pluralName]
-            ),
-        ]);
+        $event = SnapshotEvent::create();
+        $event->Title = _t(
+            self::class . '.REORDER_ROWS',
+            'Reordered {title}',
+            ['title' => $pluralName]
+        );
         $event->write();
 
         return $snapshot->applyOrigin($event);

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -355,9 +355,8 @@ class Snapshot extends DataObject
      */
     public function createSnapshotEvent(string $message, array $extraObjects = []): Snapshot
     {
-        $event = SnapshotEvent::create([
-            'Title' => $message,
-        ]);
+        $event = SnapshotEvent::create();
+        $event->Title = $message;
         $event->write();
 
         return $this->createSnapshot($event, $extraObjects);

--- a/tests/Handler/GraphQL/Middleware/RollbackHandlerTest.php
+++ b/tests/Handler/GraphQL/Middleware/RollbackHandlerTest.php
@@ -59,7 +59,8 @@ class RollbackHandlerTest extends SnapshotTestAbstract
     {
         $handler = RollbackHandler::create();
 
-        $page = SiteTree::create(['Title' => 'test']);
+        $page = SiteTree::create();
+        $page->Title = 'test';
         $page->write();
         $prevVersion = $page->Version;
         $this->createHistory($page);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1194,7 +1194,7 @@ class IntegrationTest extends SnapshotTestAbstract
 
         $this->editingPage(null);
 
-        $block = Block::create(['Title' => 'The Block']);
+        $block = Block::create();
         $block->Title = 'The Block';
         $block->write();
 

--- a/tests/SnapshotPublishableTest.php
+++ b/tests/SnapshotPublishableTest.php
@@ -405,9 +405,13 @@ class SnapshotPublishableTest extends SnapshotTestAbstract
         $this->assertEquals([$a1Block1->ID], $diff->getChanged());
 
         // Add two
-        $block1 = Block::create(['Title' => 'new one 1', 'ParentID' => $a1->ID]);
+        $block1 = Block::create();
+        $block1->Title = 'new one 1';
+        $block1->ParentID = $a1->ID;
         $block1->write();
-        $block2 = Block::create(['Title' => 'new one 2', 'ParentID' => $a1->ID]);
+        $block2 = Block::create();
+        $block2->Title = 'new one 2';
+        $block2->ParentID = $a1->ID;
         $block2->write();
 
         $diffs = $a1->getRelationDiffs(false);

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -226,7 +226,8 @@ class SnapshotTest extends SnapshotTestAbstract
             ]
         );
         $a1->Title = 'changed again';
-        $extraObject = BlockPage::create(['Title' => 'Extra page']);
+        $extraObject = BlockPage::create();
+        $extraObject->Title = 'Extra page';
         $extraObject->write();
         $snapshot = $this->snapshot($a1, [$extraObject]);
         $this->assertCount(2, $snapshot->Items());


### PR DESCRIPTION
# MISC: Extensions config cleanup.

* extension config uses named keys so they can be overridden if needed
* replacing all instances of array syntax with property syntax