### PR TITLE
NEW: Migration dev tasks for breaking changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,29 @@ SilverStripe\Snapshots\SnapshotItem:
         - ObjectHash
 ```
 
+## Upgrading to 1.x.x
+
+`1.x.x` release contains a couple of breaking changes.
+We provide upgrade path for both.
+
+### Object version DB field rename
+
+DB field `Version` on `SnapshotItem` was renamed to `ObjectVersion` to prevent naming conflicts.
+Please follow the steps below to upgrade.
+
+* run `composer update` to upgrade to the desired `1.x.x` version of this module
+* run `dev/build flush=all`
+* run `dev/tasks/migrate-object-version-task`, run via CLI
+
+### Legacy Fluent setup
+
+This is relevant only for project which use [Fluent module](https://github.com/tractorcow-farm/silverstripe-fluent) and use localised snapshot models.
+
+* run `composer update` to upgrade to the desired `1.x.x` version of this module
+* review and update your Fluent configuration as per **Localisation** section of this readme
+* run `dev/build flush=all`
+* run `dev/tasks/migrate-fluent-object-hash-task`, run via CLI
+
 ## Semantic versioning
 
 This library follows [Semver](http://semver.org). According to Semver,

--- a/src/Migration/MigrateFluentObjectHashTask.php
+++ b/src/Migration/MigrateFluentObjectHashTask.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SilverStripe\Snapshots\Migration;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\ORM\DB;
+
+class MigrateFluentObjectHashTask extends BuildTask
+{
+    /**
+     * @var string
+     */
+    private static $segment = 'migrate-fluent-object-hash-task';
+
+    /**
+     * @var string
+     */
+    protected $title = 'Migrate legacy fluent object hash to the new format for SnapshotItem';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Localise "ObjectHash" DB field of VersionedSnapshotItem table';
+
+    /**
+     * @param HTTPRequest $request
+     */
+    public function run($request): void
+    {
+        $sql = <<<EOT
+INSERT INTO "VersionedSnapshotItem_Localised" ("RecordID", "Locale", "ObjectHash")
+SELECT "VersionedSnapshotItem"."ID" as "RecordID", "VersionedSnapshot_Localised"."Locale" as "Locale", "VersionedSnapshotItem"."ObjectHash" as "ObjectHash"
+FROM "VersionedSnapshot"
+INNER JOIN "VersionedSnapshot_Localised" ON "VersionedSnapshot"."ID" = "VersionedSnapshot_Localised"."RecordID"
+INNER JOIN "VersionedSnapshotItem" ON "VersionedSnapshot"."ID" = "VersionedSnapshotItem"."SnapshotID"
+EOT;
+        DB::query($sql);
+        echo sprintf('Done, %d records created.', DB::affected_rows()) . PHP_EOL;
+    }
+}

--- a/src/Migration/MigrateObjectVersionTask.php
+++ b/src/Migration/MigrateObjectVersionTask.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SilverStripe\Snapshots\Migration;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\ORM\DB;
+
+class MigrateObjectVersionTask extends BuildTask
+{
+    /**
+     * @var string
+     */
+    private static $segment = 'migrate-object-version-task';
+
+    /**
+     * @var string
+     */
+    protected $title = 'Migrate legacy format of object version for SnapshotItem';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Migrate "Version" DB field of VersionedSnapshotItem table to "ObjectVersion"'
+    . ', this task can be run multiple times';
+
+    /**
+     * @param HTTPRequest $request
+     */
+    public function run($request): void
+    {
+        $sql = 'UPDATE "VersionedSnapshotItem" SET "ObjectVersion" = "Version" WHERE "ObjectVersion" = 0 AND "Version" > 0';
+        DB::query($sql);
+        echo sprintf('Done, %d records updated.', DB::affected_rows()) . PHP_EOL;
+    }
+}


### PR DESCRIPTION
# Migration dev tasks for breaking changes.

Covers `ObjectVersion` field rename and `SnapshotItem` Fluent setup.